### PR TITLE
Add --short-rt option to updateconf

### DIFF
--- a/cmds/cluster_cass_cmds.py
+++ b/cmds/cluster_cass_cmds.py
@@ -128,8 +128,8 @@ class ClusterUpdateconfCmd(Cmd):
             dest="hinted_handoff", default=True, help="Disable hinted handoff")
         parser.add_option('--batch-cl', '--batch-commit-log', action="store_true",
             dest="cl_batch", default=True, help="Set commit log to batch mode")
-        parser.add_option('--short-rt', '--short-rpc-timeout', action="store_true",
-            dest="short_rt", default=False, help="Short (2 seconds) rpc timeout")
+        parser.add_option('--rt', '--rpc-timeout', action="store", type='int',
+            dest="rpc_timeout", help="Set rpc timeout")
         return parser
 
     def validate(self, parser, options, args):
@@ -137,8 +137,8 @@ class ClusterUpdateconfCmd(Cmd):
 
     def run(self):
         self.cluster.set_configuration_option("hinted_handoff_enabled", self.options.hinted_handoff)
-        if self.options.short_rt:
-            self.cluster.set_configuration_option("rpc_timeout_in_ms", 4000)
+        if self.options.rpc_timeout:
+            self.cluster.set_configuration_option("rpc_timeout_in_ms", self.options.rpc_timeout)
         if self.options.cl_batch:
             self.cluster.set_configuration_option("commitlog_sync", "batch")
             self.cluster.set_configuration_option("commitlog_sync_batch_window_in_ms", 5)


### PR DESCRIPTION
While working on CASSANDRA-2643, I found it useful to be able to decrease the rpc timeout.
