### PR TITLE
don't use super()

### DIFF
--- a/cmds/cluster_cass_cmds.py
+++ b/cmds/cluster_cass_cmds.py
@@ -67,7 +67,7 @@ class ClusterStopCmd(Cmd):
                 sys.out.write(node.name + " ")
             print ""
 
-class __ClusterNodetoolCmd(Cmd):
+class _ClusterNodetoolCmd(Cmd):
     def get_parser(self):
         parser = self._get_default_parser(self.usage, self.description(), cassandra_dir=True)
         return parser
@@ -81,12 +81,12 @@ class __ClusterNodetoolCmd(Cmd):
     def run(self):
         self.cluster.nodetool(self.options.cassandra_dir, self.nodetool_cmd)
 
-class ClusterFlushCmd(__ClusterNodetoolCmd):
+class ClusterFlushCmd(_ClusterNodetoolCmd):
     usage = "usage: ccm cluster flush [options] name"
     nodetool_cmd = 'flush'
     descr_text = "Flush all (running) nodes of the cluster"
 
-class ClusterCompactCmd(__ClusterNodetoolCmd):
+class ClusterCompactCmd(_ClusterNodetoolCmd):
     usage = "usage: ccm cluster compact [options] name"
     nodetool_cmd = 'compact'
     descr_text = "Compact all (running) node of the cluster"

--- a/cmds/node_cass_cmds.py
+++ b/cmds/node_cass_cmds.py
@@ -71,7 +71,7 @@ class NodeStopCmd(Cmd):
             print >> sys.stderr, "%s is not running" % self.name
             exit(1)
 
-class __NodeToolCmd(Cmd):
+class _NodeToolCmd(Cmd):
     def get_parser(self):
         parser = self._get_default_parser(self.usage, self.description(), cassandra_dir=True)
         return parser
@@ -85,41 +85,41 @@ class __NodeToolCmd(Cmd):
     def run(self):
         self.node.nodetool(self.options.cassandra_dir, self.nodetool_cmd)
 
-class NodeRingCmd(__NodeToolCmd):
+class NodeRingCmd(_NodeToolCmd):
     usage = "usage: ccm node_name ring [options]"
     nodetool_cmd = 'ring'
     descr_text = "Print ring (connecting to node name)"
 
-class NodeFlushCmd(__NodeToolCmd):
+class NodeFlushCmd(_NodeToolCmd):
     usage = "usage: ccm node_name flush [options]"
     nodetool_cmd = 'flush'
     descr_text = "Flush node name"
 
-class NodeCompactCmd(__NodeToolCmd):
+class NodeCompactCmd(_NodeToolCmd):
     usage = "usage: ccm node_name compact [options]"
     nodetool_cmd = 'compact'
     descr_text = "Compact node name"
 
-class NodeCleanupCmd(__NodeToolCmd):
+class NodeCleanupCmd(_NodeToolCmd):
     usage = "usage: ccm node_name cleanup [options]"
     nodetool_cmd = 'cleanup'
     descr_text = "Run cleanup on node name"
 
-class NodeRepairCmd(__NodeToolCmd):
+class NodeRepairCmd(_NodeToolCmd):
     usage = "usage: ccm node_name repair [options]"
     nodetool_cmd = 'repair'
     descr_text = "Run repair on node name"
 
-class NodeDecommissionCmd(__NodeToolCmd):
+class NodeDecommissionCmd(_NodeToolCmd):
     usage = "usage: ccm node_name decommission [options]"
     nodetool_cmd = 'decommission'
     descr_text = "Run decommission on node name"
 
     def run(self):
-        __NodeToolCmd.run(self)
+        _NodeToolCmd.run(self)
         self.node.decommission()
 
-class NodeScrubCmd(__NodeToolCmd):
+class NodeScrubCmd(_NodeToolCmd):
     usage = "usage: ccm node_name scrub [options]"
     nodetool_cmd = 'scrub'
     descr_text = "Run scrub on node name"


### PR DESCRIPTION
Python's super() function often looks like the right thing to use, but it almost never is (in particular, it's not the right thing to use here).

See http://fuhm.net/super-harmful/ for more information.

This could be fixed just by calling, say, `__NodeToolCmd.__init__(self, *other_args)` directly instead of via super, but what I've done here seems a bit simpler to read and maintain.

Do it your own way if you like, this is just a suggestion.
