### PR TITLE
use $PAGER instead of forcing less

### DIFF
--- a/cmds/node_cmds.py
+++ b/cmds/node_cmds.py
@@ -64,7 +64,7 @@ class NodeRemoveCmd(Cmd):
 
 class NodeShowlogCmd(Cmd):
     def description(self):
-        return "Show the log of node name (run 'less' on its system.log)"
+        return "Show the log of node name (runs your $PAGER on its system.log)"
 
     def get_parser(self):
         usage = "usage: ccm node_name showlog [options]"
@@ -75,10 +75,8 @@ class NodeShowlogCmd(Cmd):
 
     def run(self):
         log = os.path.join(self.node.get_path(), 'logs', 'system.log')
-        try:
-            subprocess.call(['less', log])
-        except KeyboardInterrupt:
-            pass
+        pager = os.environ.get('PAGER', 'less')
+        os.execvp(pager, (pager, log))
 
 class NodeSetlogCmd(Cmd):
     def description(self):


### PR DESCRIPTION
and exec the pager instead of spawning it in a child process, so that when the user sends a ctrl-c or whatnot to the pager (for example, to cancel line numbering or to cancel the "F" (follow file, like tail -f) mode), the signal doesn't get sent to ccm and confuse things.

catching KeyboardInterrupt is a start, but we still end up with ccm exiting before the pager does, and depending on the shell and its configuration, the shell might try to take control of the tty at the same time as the pager, leading to confusion.

if we really do want to Popen the pager and do things while it runs, or afterward, we will probably want to go through the rigamarole with creating a new process group and explicitly taking over foreground control of the tty in the child process.
