### PR TITLE
fix populate for single int

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -32,7 +32,7 @@ def parse_populate_count(v):
         return None
     tmp = v.split(':')
     if len(tmp) == 1:
-        return int(tmp)
+        return int(tmp[0])
     else:
         return [ int(t) for t in tmp ]
 


### PR DESCRIPTION
Latest commit failed to parse single int for -n option. I got following error.

```
Traceback (most recent call last):
  File "/Users/yuki/Developments/bin/ccm", line 66, in <module>
    cmd.validate(parser, options, args)
  File "/Users/yuki/Developments/tools/ccm/ccmlib/cmds/cluster_cmds.py", line 62, in validate
    self.nodes = parse_populate_count(options.nodes)
  File "/Users/yuki/Developments/tools/ccm/ccmlib/cmds/cluster_cmds.py", line 35, in parse_populate_count
    return int(tmp)
TypeError: int() argument must be a string or a number, not 'list'
```

Simple fix for above.
