### PR TITLE
Allow checking out from tags, not just branch

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -37,8 +37,8 @@ def clone_development(version, verbose=False):
             out = subprocess.call(['git', 'fetch', 'origin'], cwd=target_dir, stdout=lf, stderr=lf)
         # now check out the right version
         if verbose:
-            print "Checking out requested branch (origin/%s)" % git_branch
-        out = subprocess.call(['git', 'checkout', 'origin/' + git_branch], cwd=target_dir, stdout=lf, stderr=lf)
+            print "Checking out requested branch (%s)" % git_branch
+        out = subprocess.call(['git', 'checkout', git_branch], cwd=target_dir, stdout=lf, stderr=lf)
         if int(out) != 0:
             shutil.rmtree(target_dir)
             raise Exception("Could not check out git branch %s. Is this a valid branch name? (see last.log for details)" % git_branch)


### PR DESCRIPTION
The git syntax previously used to check out a branch was 'git checkout origin/<branch name>'. This worked for branches but not tags such as '1.0.8-tentative'. Removing 'origin/' lets us do tags too.
