### PR TITLE
documentation fixes

### DIFF
--- a/README
+++ b/README
@@ -75,7 +75,7 @@ You can check that the cluster is correctly set up with
 
 
 You can then boostrap a 4th node with
-  ccm add node3 -i 127.0.0.4 -j 7400 -b
+  ccm add node4 -i 127.0.0.4 -j 7400 -b
 (populate is just a shortcut for adding multiple nodes initially)
 
 ccm then provides a number of conveniences, like flushing all of the nodes of

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -247,7 +247,7 @@ class ClusterClearCmd(Cmd):
 
 class ClusterLivesetCmd(Cmd):
     def description(self):
-        return "Pring a comma-separated list of addresses of running nodes (handful in scripts)"
+        return "Print a comma-separated list of addresses of running nodes (handful in scripts)"
 
     def get_parser(self):
         usage = "usage: ccm liveset [options]"


### PR DESCRIPTION
In README example of adding a new node, changed node3 to node4 as node3 already exists in README example
