### PR TITLE
cast int to str to avoid TypeError

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -654,7 +654,7 @@ class Node():
         conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_ENV)
         common.replace_in_file(conf_file, jmx_port_pattern, jmx_port_pattern + self.jmx_port)
         if self.remote_debug_port != '0':
-            common.replace_in_file(conf_file, remote_debug_port_pattern, 'JVM_OPTS="$JVM_OPTS -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=' + self.remote_debug_port + '"')
+            common.replace_in_file(conf_file, remote_debug_port_pattern, 'JVM_OPTS="$JVM_OPTS -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=' + str(self.remote_debug_port) + '"')
 
     def __update_status(self):
         if self.pid is None:


### PR DESCRIPTION
Doing `ccm updateconf` I get:

```
Traceback (most recent call last):
  File "./ccm", line 68, in <module>
    cmd.run()
  File "/home/eevans/dev/src/git/ccm/ccmlib/cmds/cluster_cmds.py", line 451, in run
    self.cluster.set_configuration_options(values=self.setting, batch_commitlog=self.options.cl_batch)
  File "/home/eevans/dev/src/git/ccm/ccmlib/cluster.py", line 302, in set_configuration_options
    node.import_config_files()
  File "/home/eevans/dev/src/git/ccm/ccmlib/node.py", line 563, in import_config_files
    self.__update_envfile()
  File "/home/eevans/dev/src/git/ccm/ccmlib/node.py", line 657, in __update_envfile
    common.replace_in_file(conf_file, remote_debug_port_pattern, 'JVM_OPTS="$JVM_OPTS -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=' + self.remote_debug_port + '"')
TypeError: cannot concatenate 'str' and 'int' objects
```

The (trivial )fix is to use the string representation of `self.remote_debug_port`.
