### PR TITLE
Don't ignore first arg when updating cluster conf

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -421,7 +421,6 @@ class ClusterUpdateconfCmd(Cmd):
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, load_cluster=True)
-        args = args[1:]
         try:
             self.setting = common.parse_settings(args)
         except common.ArgumentError as e:


### PR DESCRIPTION
The first arg for the cluster updateconf command was silently being ignored.  I couldn't find a good reason for why it should be ignored.
