### PR TITLE
use /usr/bin/env to invoke python

### DIFF
--- a/ccm
+++ b/ccm
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os, sys
 


### PR DESCRIPTION
since especially on OS X, the main python on the path (the one where pyyaml is more likely to be installed, among other considerations) may very well not be /usr/bin/python.
