### PR TITLE
Mark logs early on cluster startup

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -207,6 +207,10 @@ class Cluster():
             if not node.is_running():
                 p = node.start(update_pid=False)
                 started.append((node, p))
+                # ugly? indeed!
+                while not os.path.exists(node.logfilename()):
+                    time.sleep(.01)
+                marks.append((node, node.mark_log()))
 
         if no_wait and not verbose:
             time.sleep(2) # waiting 2 seconds to check for early errors and for the pid to be set
@@ -220,12 +224,6 @@ class Cluster():
                         print "[%s ERROR] %s" % (node.name, line.rstrip('\n'))
                 if verbose:
                     print "----"
-
-        for node, p in started:
-            # ugly? indeed!
-            while not os.path.exists(node.logfilename()):
-                time.sleep(.01)
-            marks.append((node, node.mark_log()))
 
         self.__update_pids(started)
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -224,10 +224,7 @@ class Node():
         """
         with open(self.logfilename()) as f:
             f.seek(0, os.SEEK_END)
-            mark = f.tell() - 1024
-            if mark < 0:
-                mark = 0
-            return mark
+            return f.tell()
 
     # This will return when exprs are found or it timeouts
     def watch_log_for(self, exprs, from_mark=None, timeout=60):


### PR DESCRIPTION
A while ago we added a hack for this by rewinding the mark 1k as a buffer.  However as our logging gets more verbose (as it is in trunk with more flush activity for system tables) this isn't sufficient.  Instead, we can mark the logs as soon as we begin launching nodes, and remove the previous hack.
