### PR TITLE
If the CASSANDRA_INCLUDE environment variable is already set, don't over...

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -91,7 +91,8 @@ def make_cassandra_env(cassandra_dir, node_path):
     ]
     common.replaces_in_file(dst, replacements)
     env = os.environ.copy()
-    env['CASSANDRA_INCLUDE'] = os.path.join(dst)
+    if 'CASSANDRA_INCLUDE' not in env:
+        env['CASSANDRA_INCLUDE'] = os.path.join(dst)
     return env
 
 def get_stress_bin(cassandra_dir):


### PR DESCRIPTION
I'm working on code coverage reports and I need to be able to modify the classpath before Cassandra starts up. It looks like CASSANDRA_INCLUDE is the place to do that, I modified ccm to not overwrite my custom CASSANDRA_INCLUDE setting.
