### PR TITLE
Adds support for a cluster-wide cassandra.in.sh file that is appeneded to the node specific one

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -90,6 +90,17 @@ def make_cassandra_env(cassandra_dir, node_path):
         ('CASSANDRA_CONF=', '\tCASSANDRA_CONF=%s' % os.path.join(node_path, 'conf'))
     ]
     common.replaces_in_file(dst, replacements)
+
+    # If a cluster-wide cassandra.in.sh file exists in the parent
+    # directory, append it to the node specific one:
+    cluster_sh_file = os.path.join(node_path, os.path.pardir, 'cassandra.in.sh')
+    if os.path.exists(cluster_sh_file):
+        append = open(cluster_sh_file).read()
+        with open(dst, 'a') as f:
+            f.write('\n\n### Start Cluster wide config ###\n')
+            f.write(append)
+            f.write('\n### End Cluster wide config ###\n\n')
+
     env = os.environ.copy()
     env['CASSANDRA_INCLUDE'] = os.path.join(dst)
     return env


### PR DESCRIPTION
This adds support for a common cassandra.in.sh file among all the nodes started by ccm. I needed this for integration with [cassandra-dtest](https://github.com/riptano/cassandra-dtest) for code coverage reporting.

If you can see a better way of doing this let me know, this has been tested by me for about a week with nothing blowing up.
