### PR TITLE
added option "ipprefix"

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -112,7 +112,7 @@ class Cluster():
             self.__update_topology_files()
         return self
 
-    def populate(self, nodes, debug=False, tokens=None, use_vnodes=False):
+    def populate(self, nodes, debug=False, tokens=None, use_vnodes=False, ipprefix='127.0.0.'):
         node_count = nodes
         dcs = []
         if isinstance(nodes, list):
@@ -143,12 +143,12 @@ class Cluster():
 
             binary = None
             if self.version() >= '1.2':
-                binary = ('127.0.0.%s' % i, 9042)
+                binary = ('%s%s' % (ipprefix, i), 9042)
             node = Node('node%s' % i,
                         self,
                         False,
-                        ('127.0.0.%s' % i, 9160),
-                        ('127.0.0.%s' % i, 7000),
+                        ('%s%s' % (ipprefix, i), 9160),
+                        ('%s%s' % (ipprefix, i), 7000),
                         str(7000 + i * 100),
                         (str(0),  str(2000 + i * 100))[debug == True],
                         tk,

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -55,6 +55,8 @@ class ClusterCreateCmd(Cmd):
             help="Path to the cassandra directory to use [default %default]", default="./")
         parser.add_option('-n', '--nodes', type="string", dest="nodes",
             help="Populate the new cluster with that number of nodes (a single int or a colon-separate list of ints for multi-dc setups)")
+        parser.add_option('-i', '--ipprefix', type="string", dest="ipprefix", default="127.0.0.",
+            help="Ipprefix to use to create the ip of a node while populating")
         parser.add_option('-s', "--start", action="store_true", dest="start_nodes",
             help="Start nodes added through -s", default=False)
         parser.add_option('-d', "--debug", action="store_true", dest="debug",
@@ -101,7 +103,7 @@ class ClusterCreateCmd(Cmd):
                     cluster.set_log_level("DEBUG")
                 if self.options.trace_log:
                     cluster.set_log_level("TRACE")
-                cluster.populate(self.nodes, use_vnodes=self.options.vnodes)
+                cluster.populate(self.nodes, use_vnodes=self.options.vnodes, ipprefix=self.options.ipprefix)
                 if self.options.start_nodes:
                     cluster.start(verbose=self.options.debug, wait_for_binary_proto=self.options.binary_protocol)
             except common.ArgumentError as e:
@@ -187,6 +189,8 @@ class ClusterPopulateCmd(Cmd):
             help="Enable remote debugging options", default=False)
         parser.add_option('--vnodes', action="store_true", dest="vnodes",
             help="Populate using vnodes", default=False)
+        parser.add_option('-i', '--ipprefix', type="string", dest="ipprefix", default="127.0.0.",
+            help="Ipprefix to use to create the ip of a node")
         return parser
 
     def validate(self, parser, options, args):
@@ -195,7 +199,7 @@ class ClusterPopulateCmd(Cmd):
 
     def run(self):
         try:
-            self.cluster.populate(self.nodes, self.options.debug, use_vnodes=self.options.vnodes)
+            self.cluster.populate(self.nodes, self.options.debug, use_vnodes=self.options.vnodes, ipprefix=self.options.ipprefix)
         except common.ArgumentError as e:
             print >> sys.stderr, str(e)
             exit(1)


### PR DESCRIPTION
This is the first of two patches to easily switch to another ipspace while running the tests for java-driver.
The other half (java-driver) is under https://github.com/damoon/java-driver/tree/ipprefix.
In combination it enables developing/jenkins-building the java-driver without shutting down an already running cassandra instance at 127.0.0.1.
- the ipprefix is "127.0.0." by default
- nodeips get generated in this ipspace while populating
- it is an optional parameter for create and populate

It is passing all tests for java-driver in the new ipspace on my local laptop.
