### PR TITLE
Adds up/down aliases for cluster and node start/stop commands.

### DIFF
--- a/ccm
+++ b/ccm
@@ -26,6 +26,8 @@ def print_global_usage():
         if not cmd:
             print "Internal error, unknown command {0}".format(cmd_name)
             exit(1)
+        if cmd.is_hidden():
+            continue #Don't show hidden/aliased commands
         print "  {0:14} {1}".format(cmd_name, cmd.description())
     print "or <node_name> is the name of a node of the current cluster and <node_cmd> is one of"
     for cmd_name in node_cmds.node_cmds():
@@ -33,6 +35,8 @@ def print_global_usage():
         if not cmd:
             print "Internal error, unknown command {0}".format(cmd_name)
             exit(1)
+        if cmd.is_hidden():
+            continue #Don't show hidden/aliased commands
         print "  {0:14} {1}".format(cmd_name, cmd.description())
     exit(1)
 

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -1,4 +1,5 @@
 import os, sys, shutil
+import command
 from command import Cmd
 
 from ccmlib import common, repository
@@ -17,7 +18,9 @@ def cluster_cmds():
         "clear",
         "liveset",
         "start",
+        "up",
         "stop",
+        "down",
         "flush",
         "compact",
         "stress",
@@ -346,7 +349,7 @@ class ClusterClearrepoCmd(Cmd):
 
 class ClusterStartCmd(Cmd):
     def description(self):
-        return "Start all the non started nodes of the current cluster"
+        return "Start all the non started nodes of the current cluster (alias: 'up')"
 
     def get_parser(self):
         usage = "usage: ccm cluter start [options]"
@@ -371,9 +374,14 @@ class ClusterStartCmd(Cmd):
                 print >> sys.stderr, line.rstrip('\n')
             exit(1)
 
+@command.hidden
+class ClusterUpCmd(ClusterStartCmd):
+    """Alias for ClusterStartCmd"""
+    pass
+
 class ClusterStopCmd(Cmd):
     def description(self):
-        return "Stop all the nodes of the cluster"
+        return "Stop all the nodes of the cluster (alias: 'down')"
 
     def get_parser(self):
         usage = "usage: ccm cluster stop [options] name"
@@ -402,6 +410,11 @@ class ClusterStopCmd(Cmd):
         except NodeError as e:
             print >> sys.stderr, str(e)
             exit(1)
+
+@command.hidden
+class ClusterDownCmd(ClusterStopCmd):
+    """Alias for ClusterStopCmd"""
+    pass
 
 class _ClusterNodetoolCmd(Cmd):
     def get_parser(self):

--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -78,5 +78,16 @@ class Cmd(object):
             help="Directory for the cluster files [default to ~/.ccm]")
         return parser
 
+    def is_hidden(self):
+        return False
+
     def description():
         return ""
+
+def hidden(klass):
+    """Decorator to hide a command from the help system, useful for
+    aliases of other commands"""
+    def is_hidden(cls):
+        return True
+    klass.is_hidden = is_hidden
+    return klass

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -1,4 +1,5 @@
 import os, sys
+import command
 from command import Cmd
 
 from ccmlib import common
@@ -11,7 +12,9 @@ def node_cmds():
         "showlog",
         "setlog",
         "start",
+        "up",
         "stop",
+        "down",
         "ring",
         "flush",
         "compact",
@@ -116,7 +119,7 @@ class NodeClearCmd(Cmd):
 
 class NodeStartCmd(Cmd):
     def description(self):
-        return "Start a node"
+        return "Start a node (alias: 'up')"
 
     def get_parser(self):
         usage = "usage: ccm node start [options] name"
@@ -146,10 +149,15 @@ class NodeStartCmd(Cmd):
             for line in e.process.stderr:
                 print >> sys.stderr, line.rstrip('\n')
             exit(1)
+    
+@command.hidden
+class NodeUpCmd(NodeStartCmd):
+    """Alias for NodeStartCmd"""
+    pass
 
 class NodeStopCmd(Cmd):
     def description(self):
-        return "Stop a node"
+        return "Stop a node (alias: 'down')"
 
     def get_parser(self):
         usage = "usage: ccm node stop [options] name"
@@ -173,6 +181,11 @@ class NodeStopCmd(Cmd):
         except NodeError as e:
             print >> sys.stderr, str(e)
             exit(1)
+
+@command.hidden
+class NodeDownCmd(NodeStopCmd):
+    """Alias for NodeStopCmd"""
+    pass
 
 class _NodeToolCmd(Cmd):
     def get_parser(self):


### PR DESCRIPTION
After using ccm everyday I found this to be annoying enough to fix:

ccm status uses the word 'UP' and 'DOWN' for nodes, but has commands 'start' and 'stop' to actually change that status. The mnemonic for me is broken as I'm always typing up/down instead of start/stop, so I added aliases so that I can use any of the following:

ccm start
ccm stop
ccm up
ccm down
ccm node1 up
ccm node1 down
ccm node1 start
ccm node1 stop

I didn't want this to be too crufty, so I'm hiding these extra up/down commands from the help system and only adding a comment to the description of the original command. 
