### PR TITLE
Adds optional cluster name to remove command.

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -291,7 +291,7 @@ class ClusterRemoveCmd(Cmd):
             cluster = Cluster.load(self.path, self.other_cluster)
             cluster.remove()
             # Remove CURRENT flag if the specified cluster is the current cluster:
-            if hasattr(self, 'cluster') and self.cluster.name == self.other_cluster:
+            if self.other_cluster == common.current_cluster_name(self.path):
                 os.remove(os.path.join(self.path, 'CURRENT'))
         else:
             # Remove the current cluster:


### PR DESCRIPTION
This is my proposed fix for issue #53.

If you don't like modifying the remove command like this, I can understand, in that case it should report an error to the user about extra unknown options at the end of the command, instead of deleting the current cluster.
