### PR TITLE
Two issues regarding remote git fetching

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -43,7 +43,13 @@ def clone_development(version, verbose=False):
                 if verbose:
                     print "Fetching Cassandra updates..."
                 out = subprocess.call(
-                    ['git', 'fetch', '--all'],
+                    ['git', 'fetch', '-t', '--all'],
+                    cwd=local_git_cache, stdout=lf, stderr=lf)
+                # Even though this is a bare repository, git still
+                # maintains a local trunk branch, we need to update
+                # this each time:
+                out = subprocess.call(
+                    ['git', 'fetch', 'origin', 'trunk:trunk'],
                     cwd=local_git_cache, stdout=lf, stderr=lf)
 
             #Checkout the version we want from the local cache:


### PR DESCRIPTION
This fixes two issues with remote git fetching:
- I didn't realize that 'git fetch' did not pull new tags from the remote. I added the flag to do it.
- bare git repositories still maintain a local trunk/master branch which needs to be updated to the remote HEAD each time. This was needed for `ccm create -v git:trunk trunk` otherwise the old HEAD was used. (other branch names were unaffected, just trunk.)
