### PR TITLE
Fixes new/updated branch and tag fetching from remote repository.

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -36,20 +36,14 @@ def clone_development(version, verbose=False):
                 if verbose:
                     print "Cloning Cassandra..."
                 out = subprocess.call(
-                    ['git', 'clone', '--bare', GIT_REPO, local_git_cache], 
+                    ['git', 'clone', '--mirror', GIT_REPO, local_git_cache], 
                     cwd=__get_dir(), stdout=lf, stderr=lf)
                 assert out == 0, "Could not do a git clone"
             else: 
                 if verbose:
                     print "Fetching Cassandra updates..."
                 out = subprocess.call(
-                    ['git', 'fetch', '-t', '--all'],
-                    cwd=local_git_cache, stdout=lf, stderr=lf)
-                # Even though this is a bare repository, git still
-                # maintains a local trunk branch, we need to update
-                # this each time:
-                out = subprocess.call(
-                    ['git', 'fetch', 'origin', 'trunk:trunk'],
+                    ['git', 'fetch', '-fup', 'origin', '+refs/*:refs/*'],
                     cwd=local_git_cache, stdout=lf, stderr=lf)
 
             #Checkout the version we want from the local cache:


### PR DESCRIPTION
Fetches branches and tags now in one step using a single refspec.
Removes the need to update the local branch manually.

Supercedes the changes from #58
