### PR TITLE
use /usr/bin/env to invoke python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from distutils.core import setup
 from os.path import abspath, join, dirname


### PR DESCRIPTION
This allows running setup.py with non-system python environments. 
