### PR TITLE
Workaround patch until CASSANDRA-5543 is resolved

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -121,7 +121,7 @@ def compile_version(version, target_dir, verbose=False):
             ret_val = 1
             while attempt < 3 and ret_val is not 0:
                 if attempt > 0:
-                    print "`ant jar` failed. Retry #%s..." % attempt
+                    lf.write("\n\n`ant jar` failed. Retry #%s...\n\n" % attempt)
                 ret_val = subprocess.call(['ant', 'jar'], cwd=target_dir, stdout=lf, stderr=lf)
                 attempt += 1
             if ret_val is not 0:


### PR DESCRIPTION
This will get around issues in automated environments, especially where testing is concerned.

The current workaround is to check the log at `.ccm/repository/last.log`, validate the issue is the same (typically is), `cd .ccm/repository/<version>/`, then run `ant jar` until it compiles successfully.
