### PR TITLE
change requires to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url='https://github.com/pcmanus/ccm',
     packages=['ccmlib', 'ccmlib.cmds'],
     scripts=['ccm'],
-    requires=['pyYaml'],
+    install_requires=['pyYaml'],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",


### PR DESCRIPTION
Currently if you install ccm it dies out because pyyaml isn't installed via requires.  switching to install_requires should fix the issue
