### PR TITLE
Fix from_mark arg error in Cluster.start method

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -235,9 +235,10 @@ class Cluster():
             # 0.7 gossip messages seems less predictible that from 0.8 onwards and
             # I don't care enough
             for node, mark in marks:
-                for other_node, _ in marks:
+                for other_node, other_mark in marks:
                     if other_node is not node:
-                        node.watch_log_for_alive(other_node, from_mark=mark)
+                        node.watch_log_for_alive(other_node,
+                                                 from_mark=other_mark)
 
         if wait_for_binary_proto:
             for node, _ in started:


### PR DESCRIPTION
Sometimes the `watch_log_for_alive` method failed and raise Timeout exception in my test scenario.
Then I found it was because the from_mark args picked wrong seek position and the `watch_log_for` method missed the `...is UP` line.
