### PR TITLE
Hold off on reading from a log file if it does not yet exist

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -249,6 +249,10 @@ class Node():
         reads = ""
         if len(tofind) == 0:
             return None
+        start_time = time.time()
+        while time.time() - start_time < 10:
+            if os.path.isfile(self.logfilename()):
+                break
         with open(self.logfilename()) as f:
             if from_mark:
                 f.seek(from_mark)


### PR DESCRIPTION
I was running into issues when testing on 1.2.11.

Error:
IOError: [Errno 2] No such file or directory: '/var/folders/mh/h_jxf_b943x5tl9kv_hf2j3h0000gn/T/1383353300531-0/test/node1/logs/system.log'
