### PR TITLE
Removes unnecessary mark_log() call that was throwing off the watch_log_for* functions

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -217,7 +217,6 @@ class Cluster():
             time.sleep(2) # waiting 2 seconds to check for early errors and for the pid to be set
         else:
             for node, p in started:
-                marks.append((node, node.mark_log()))
                 try:
                     node.watch_log_for("Listening for thrift clients...", process=p, verbose=verbose)
                 except RuntimeError:


### PR DESCRIPTION
I think this was perhaps left out in your refactoring of this block in c553f62e3afc95323808e383a49dca09638aa0b4 - that is, I don't see the reason to add a (node,mark) twice.

This fix makes the repair_test dtest pass, whereas it's currently broken without it.
