### PR TITLE
Removes check for IP:port availability if using replace_address.

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -352,7 +352,7 @@ class Node():
             raise NodeError("%s is already running" % self.name)
 
         for itf in self.network_interfaces.values():
-            if itf is not None:
+            if itf is not None and replace_address is None:
                 common.check_socket_available(itf)
 
         if wait_other_notice:


### PR DESCRIPTION
Normally you want ccm to warn you that an IP:port is already in use,
however if you are using replace_address it's assumed you know what
you're doing. If the IP:port is in use, you'll see a C\* error rather than a ccm error.

/cc PR #85
