### PR TITLE
Moves flush directory to the local node's path.

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -785,7 +785,8 @@ class Node():
         data['data_file_directories'] = [ os.path.join(self.get_path(), 'data') ]
         data['commitlog_directory'] = os.path.join(self.get_path(), 'commitlogs')
         data['saved_caches_directory'] = os.path.join(self.get_path(), 'saved_caches')
-        data['flush_directory'] = os.path.join(self.get_path(), 'flush')
+        if self.cluster.version() >= "2.1":
+            data['flush_directory'] = os.path.join(self.get_path(), 'flush')
 
         if self.cluster.partitioner:
             data['partitioner'] = self.cluster.partitioner


### PR DESCRIPTION
This is needed due to [CASSANDRA-6357](https://issues.apache.org/jira/browse/CASSANDRA-6357), which creates a new directory that defaults to /var/lib/cassandra/flush.
