### PR TITLE
Fix jdwp configuration

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -911,7 +911,7 @@ class Node():
 
     def __update_envfile(self):
         jmx_port_pattern='JMX_PORT='
-        remote_debug_port_pattern='address='
+        remote_debug_port_pattern='-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address='
         conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_ENV)
         common.replace_in_file(conf_file, jmx_port_pattern, jmx_port_pattern + self.jmx_port)
         if self.remote_debug_port != '0':


### PR DESCRIPTION
When bootstrapping a new node, the __update_envfile method was incorrectly enabling JDWP twice which makes cassandra fail to startup. Updating the replacement pattern, making it more specific, fixes the problem, otherwise it also matches the MX4J config.
