### PR TITLE
Require six >=1.4.1 for six.moves.urllib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url='https://github.com/pcmanus/ccm',
     packages=['ccmlib', 'ccmlib.cmds'],
     scripts=['ccm'],
-    install_requires=['pyYaml', 'six'],
+    install_requires=['pyYaml', 'six >=1.4.1'],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",


### PR DESCRIPTION
`six.moves.urllib` was [added in version 1.4.0](https://bitbucket.org/gutworth/six/src/dea5c233c6f404bf3468195ae9ef80497d08258f/CHANGES?at=default#cl-111) and then fixed in 1.4.1, so this adds that requirement explicitly.

This should fix #112.
