### PR TITLE
Adds nodetool as a node command

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -35,6 +35,7 @@ def node_cmds():
         "status",
         "setdir",
         "version",
+        "nodetool"
     ]
 
 class NodeShowCmd(Cmd):
@@ -207,6 +208,13 @@ class _NodeToolCmd(Cmd):
 
     def run(self):
         self.node.nodetool(self.nodetool_cmd)
+
+class NodeNodetoolCmd(_NodeToolCmd):
+    usage = "usage: ccm node_name nodetool [options]"
+    descr_text = "Run nodetool (connecting to node name)"
+
+    def run(self):
+        self.node.nodetool(" ".join(self.args[1:]))
 
 class NodeRingCmd(_NodeToolCmd):
     usage = "usage: ccm node_name ring [options]"
@@ -523,3 +531,4 @@ class NodeSetdirCmd(Cmd):
         except common.ArgumentError as e:
             print_(str(e), file=sys.stderr)
             exit(1)
+


### PR DESCRIPTION
Not sure if this is contrary to how you saw ccm working or not @pcmanus, but this was pretty useful for me.

This command adds a new 'nodetool' node command. It does replicate a lot of the commands already baked into ccm, but it gives access to all the things it doesn't. So you can do things like:

```
ccm node1 nodetool cfhistograms ks cf
ccm node2 nodetool snapshot
```

One caveat to this is that the nodetool arguments aren't usable without escaping, because they are interpreted as ccm arguments, not nodetool arguments. Escaping with a double dash works though, and looks like:

```
 ccm node3 nodetool -- -pw asdf describering Keyspace1
```
