### PR TITLE
default node memory config to prevent ccm from using all avail mem

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -157,6 +157,9 @@ def make_cassandra_env(cassandra_dir, node_path):
 
     env = os.environ.copy()
     env['CASSANDRA_INCLUDE'] = os.path.join(dst)
+    env['MAX_HEAP_SIZE'] = os.environ.get('CCM_MAX_HEAP_SIZE', '500M')
+    env['HEAP_NEWSIZE'] = os.environ.get('CCM_HEAP_NEWSIZE', '50M')
+    
     return env
 
 def check_win_requirements():


### PR DESCRIPTION
Users can set custom values by specifying
CCM_MAX_HEAP_SIZE AND CCM_HEAP_NEWSIZE
