### PR TITLE
Implemented graceful shutdown of C* on Windows

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -515,6 +515,10 @@ class Node():
             if not gently:
                 args.append('-f')
             proc = subprocess.Popen(args, cwd= self.get_bin_dir(), shell=True, stdout=subprocess.PIPE)
+
+            pidfile = self.get_path() + "/cassandra.pid"
+            if (os.path.isfile(pidfile)):
+                os.remove(pidfile)
         
             still_running = self.is_running()
             if still_running and wait:


### PR DESCRIPTION
On clusters of C\* version 2.1 or greater, ccm now calls stop-server.bat for graceful shutdown. This patch also includes fixes for windows specific race conditions where nodes would not stop, or upon restart, nodes would have the wrong pid. Again, I have tested this with an older C\* install to ensure old functionality is not broken, as well as testing on Unix.
