### PR TITLE
Use setuptools to run with install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
 from os.path import abspath, join, dirname
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
 
 setup(
     name='ccm',


### PR DESCRIPTION
This resolves the following issue when running at `python setup.py install` command:

```
sudo python setup.py install
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_requires'
  warnings.warn(msg)
```
