### PR TITLE
Add node 'relocate' command.

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -71,7 +71,7 @@ class Cluster():
         
         # if any nodes have a data center, let's update the topology
         if any( [node.data_center for node in self.nodes.values()] ):
-            self.__update_topology_files()
+            self.update_topology_files()
         
         return self
 
@@ -127,7 +127,7 @@ class Cluster():
         node.set_log_level(self.__log_level)
         node._save()
         if data_center is not None:
-            self.__update_topology_files()
+            self.update_topology_files()
         return self
 
     def populate(self, nodes, debug=False, tokens=None, use_vnodes=False, ipprefix='127.0.0.'):
@@ -395,15 +395,15 @@ class Cluster():
         for node, p, _ in started:
             node._update_pid(p)
 
-    def __update_topology_files(self):
-        dcs = [('default', 'dc1')]
+    def update_topology_files(self):
+        dcs = [('default', 'dc1', 'r1')]
         for node in self.nodelist():
             if node.data_center is not None:
-                dcs.append((node.address(), node.data_center))
+                dcs.append((node.address(), node.data_center, node.rack or 'r1'))
 
         content = ""
-        for k, v in dcs:
-            content = "%s%s=%s:r1\n" % (content, k, v)
+        for n, d, r in dcs:
+            content = "%s%s=%s:%s\n" % (content, n, d, r)
 
         for node in self.nodelist():
             topology_file = os.path.join(node.get_conf_dir(), 'cassandra-topology.properties')

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -35,7 +35,8 @@ def node_cmds():
         "status",
         "setdir",
         "version",
-        "nodetool"
+        "nodetool",
+        "relocate"
     ]
 
 class NodeShowCmd(Cmd):
@@ -538,3 +539,25 @@ class NodeSetdirCmd(Cmd):
             print_(str(e), file=sys.stderr)
             exit(1)
 
+class NodeRelocateCmd(Cmd):
+    def description(self):
+        return "Change the node's topology information"
+
+    def get_parser(self):
+        usage = "usage: ccm node_name relocate datacenter rack"
+        parser = self._get_default_parser(usage, self.description())
+        return parser
+
+    def validate(self, parser, options, args):
+        Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
+        if len(args) == 1:
+            print_('Missing datacenter and rack', file=sys.stderr)
+            parser.print_help()
+        elif len(args) == 2:
+            print_('Missing rack', file=sys.stderr)
+            parser.print_help()
+        self.data_center = args[1]
+        self.rack = args[2]
+
+    def run(self):
+        self.node.relocate(self.data_center, self.rack)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -67,6 +67,7 @@ class Node():
         self.initial_token = initial_token
         self.pid = None
         self.data_center = None
+        self.rack = None
         self.__config_options = {}
         self.__cassandra_dir = None
         self.__global_log_level = None
@@ -108,6 +109,8 @@ class Node():
                 node.__config_options = data['config_options']
             if 'data_center' in data:
                 node.data_center = data['data_center']
+            if 'rack' in data:
+                node.rack = data['rack']
             return node
         except KeyError as k:
             raise common.LoadError("Error Loading " + filename + ", missing property: " + str(k))
@@ -822,6 +825,11 @@ class Node():
                 shutil.copy(filename, self.get_bin_dir())
                 common.add_exec_permission(bin_dir, name)
 
+    def relocate(self, data_center, rack):
+        self.data_center = data_center
+        self.rack = rack
+        self.cluster.update_topology_files()
+
     def __clean_bat(self):
         # While the Windows specific changes to the batch files to get them to run are
         # fairly extensive and thus pretty brittle, all the changes are very unique to
@@ -879,6 +887,8 @@ class Node():
             values['cassandra_dir'] = self.__cassandra_dir
         if self.data_center:
             values['data_center'] = self.data_center
+        if self.rack:
+            values['rack'] = self.rack
         if self.remote_debug_port:
             values['remote_debug_port'] = self.remote_debug_port
         with open(filename, 'w') as f:


### PR DESCRIPTION
This adds a new node command that allows changing the datacenter and rack information in `cassandra-topology.properties` (I need this in order to write a test for [JAVA-315](https://datastax-oss.atlassian.net/browse/JAVA-315)).

Example:

```
ccm create twodc -n1:1 -s -b -v 2.1.0-rc1
ccm node1 relocate dc1 r2
```
