### PR TITLE
Binary tarball support

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -304,6 +304,12 @@ def get_version_from_build(cassandra_dir=None, node_path=None):
     if cassandra_dir is None and node_path is not None:
         cassandra_dir = get_cassandra_dir_from_cluster_conf(node_path)
     if cassandra_dir is not None:
+        # Binary installs will have a 0.version.txt file
+        version_file = os.path.join(cassandra_dir, '0.version.txt')
+        if os.path.exists(version_file):
+            with open(version_file) as f:
+                return f.read().strip()
+        # Source installs we can read from build.xml
         build = os.path.join(cassandra_dir, 'build.xml')
         with open(build) as f:
             for line in f:


### PR DESCRIPTION
This adds support for binary tarballs. The syntax for installing a binary version of c\* I've adapted the git: syntax and used binary:

 ccm create -v binary:2.0.9 test

This allows us to run dtests against prepackaged builds, and this has the added bonus that you do not need to have a full JDK or ant installed. JRE is sufficient.
