### PR TITLE
New version semantics: stable, oldstable, and testing.

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -223,7 +223,7 @@ def get_tagged_version_numbers(series='stable'):
         # Stable and oldstable releases are just a number:
         tag_regex = re.compile('^refs/tags/cassandra-([0-9]+\.[0-9]+\.[0-9]+$)')
 
-    r = urllib.request.urlopen('https://api.github.com/repos/apache/cassandra/git/refs/tags')
+    r = urllib.request.urlopen(GITHUB_TAGS)
     for ref in (i.get('ref','') for i in json.loads(r.read())) :
         m = tag_regex.match(ref)
         if m:


### PR DESCRIPTION
This adds three special version names: stable, oldstable, and testing.

Examples:

```
ccm create -v stable test # downlaods the latest stable version of C*, currently 2.0.9
ccm create -v binary:stable test # akin to #136, this downloads a binary version of 2.0.9
ccm create -v oldstable # Downloads the latest version of the previous major version, currently 1.2.18

ccm create -v testing test # This downloads the latest testing version, currently 1.2.1-rc3
```

The last example isn't working because it appears there is no tarball for rc3 published yet, even though there's a tag. I think acceptable behaviour is for it to error our like it is rather than grab the previous version.
