### PR TITLE
Renamed README to README.md in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name='ccm',
     version='1.1',
     description='Cassandra Cluster Manager',
-    long_description=open(abspath(join(dirname(__file__), 'README'))).read(),
+    long_description=open(abspath(join(dirname(__file__), 'README.md'))).read(),
     author='Sylvain Lebresne',
     author_email='sylvain@datastax.com',
     url='https://github.com/pcmanus/ccm',


### PR DESCRIPTION
Broken setup.py:

2014-08-06 08:33:52.569 | ++ sudo pip install -e /opt/stack/new/ccm
2014-08-06 08:33:52.899 | Obtaining file:///opt/stack/new/ccm
2014-08-06 08:33:53.004 |   Running setup.py (path:/opt/stack/new/ccm/setup.py) egg_info for package from file:///opt/stack/new/ccm
2014-08-06 08:33:53.182 |     Traceback (most recent call last):
2014-08-06 08:33:53.182 |       File "", line 17, in 
2014-08-06 08:33:53.182 |       File "/opt/stack/new/ccm/setup.py", line 15, in 
2014-08-06 08:33:53.182 |         long_description=open(abspath(join(dirname(**file**), 'README'))).read(),
2014-08-06 08:33:53.182 |     IOError: [Errno 2] No such file or directory: '/opt/stack/new/ccm/README'
2014-08-06 08:33:53.187 |     Complete output from command python setup.py egg_info:
2014-08-06 08:33:53.187 |     Traceback (most recent call last):
2014-08-06 08:33:53.187 | 
2014-08-06 08:33:53.187 |   File "", line 17, in 
2014-08-06 08:33:53.187 | 
2014-08-06 08:33:53.187 |   File "/opt/stack/new/ccm/setup.py", line 15, in 
2014-08-06 08:33:53.187 | 
2014-08-06 08:33:53.187 |     long_description=open(abspath(join(dirname(**file**), 'README'))).read(),
2014-08-06 08:33:53.187 | 
2014-08-06 08:33:53.187 | IOError: [Errno 2] No such file or directory: '/opt/stack/new/ccm/README'
