### PR TITLE
Install and run opscenter and install and run agent on nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 build/
 dist/
 venv/
+ccm.iml
+.idea/
+ccm.egg-info/

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -91,6 +91,9 @@ class Cluster(object):
         common.validate_install_dir(self.__install_dir)
         return self.__install_dir
 
+    def hasOpscenter(self):
+        return False
+
     def nodelist(self):
         return [ self.nodes[name] for name in sorted(self.nodes.keys()) ]
 

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -59,6 +59,8 @@ class ClusterCreateCmd(Cmd):
             help="Set the cluster partitioner class")
         parser.add_option('-v', "--version", type="string", dest="version",
             help="Download and use provided cassandra or dse version. If version is of the form 'git:<branch name>', then the specified cassandra branch will be downloaded from the git repo and compiled. (takes precedence over --install-dir)", default=None)
+        parser.add_option('-o', "--opsc", type="string", dest="opscenter",
+            help="Download and use provided opscenter version to install with DSE. Will have no effect on cassandra installs)", default=None)
         parser.add_option("--dse", action="store_true", dest="dse",
             help="Use with -v to indicate that the version being loaded is DSE")
         parser.add_option("--dse-username", type="string", dest="dse_username",
@@ -115,7 +117,7 @@ class ClusterCreateCmd(Cmd):
     def run(self):
         try:
             if self.options.dse or (not self.options.version and common.isDse(self.options.install_dir)):
-                cluster = DseCluster(self.path, self.name, install_dir=self.options.install_dir, version=self.options.version, dse_username=self.options.dse_username, dse_password=self.options.dse_password, verbose=True)
+                cluster = DseCluster(self.path, self.name, install_dir=self.options.install_dir, version=self.options.version, dse_username=self.options.dse_username, dse_password=self.options.dse_password, opscenter=self.options.opscenter, verbose=True)
             else:
                 cluster = Cluster(self.path, self.name, install_dir=self.options.install_dir, version=self.options.version, verbose=True)
         except OSError as e:

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -18,6 +18,7 @@ import fnmatch
 BIN_DIR= "bin"
 CASSANDRA_CONF_DIR= "conf"
 DSE_CASSANDRA_CONF_DIR="resources/cassandra/conf"
+OPSCENTER_CONF_DIR= "conf"
 
 CASSANDRA_CONF = "cassandra.yaml"
 LOG4J_CONF = "log4j-server.properties"
@@ -277,6 +278,18 @@ def isDse(install_dir):
     dse_script = os.path.join(bin_dir, 'dse')
     return os.path.exists(dse_script)
 
+def isOpscenter(install_dir):
+    if install_dir is None:
+        raise ArgumentError('Undefined installation directory')
+
+    bin_dir = os.path.join(install_dir, BIN_DIR)
+
+    if not os.path.exists(bin_dir):
+        raise ArgumentError('Installation directory does not contain a bin directory')
+
+    opscenter_script = os.path.join(bin_dir, 'opscenter')
+    return os.path.exists(opscenter_script)
+
 def validate_install_dir(install_dir):
     if install_dir is None:
         raise ArgumentError('Undefined installation directory')
@@ -289,11 +302,14 @@ def validate_install_dir(install_dir):
     bin_dir = os.path.join(install_dir, BIN_DIR)
     if isDse(install_dir):
         conf_dir = os.path.join(install_dir, DSE_CASSANDRA_CONF_DIR)
+    elif isOpscenter(install_dir):
+        conf_dir = os.path.join(install_dir, OPSCENTER_CONF_DIR)
     else:
         conf_dir = os.path.join(install_dir, CASSANDRA_CONF_DIR)
     cnd = os.path.exists(bin_dir)
     cnd = cnd and os.path.exists(conf_dir)
-    cnd = cnd and os.path.exists(os.path.join(conf_dir, CASSANDRA_CONF))
+    if not isOpscenter(install_dir):
+        cnd = cnd and os.path.exists(os.path.join(conf_dir, CASSANDRA_CONF))
     if not cnd:
         raise ArgumentError('%s does not appear to be a cassandra or dse installation directory' % install_dir)
 

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -1,4 +1,8 @@
 # ccm clusters
+import os
+import shutil
+import subprocess
+import signal
 
 from six import iteritems
 from ccmlib import repository
@@ -7,16 +11,34 @@ from ccmlib.dse_node import DseNode
 from ccmlib import common
 
 class DseCluster(Cluster):
-    def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, dse_username=None, dse_password=None, verbose=False):
+    def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, dse_username=None, dse_password=None, opscenter=None, verbose=False):
         self.dse_username = dse_username
         self.dse_password = dse_password
+        self.opscenter = opscenter
         super(DseCluster, self).__init__(path, name, partitioner, install_dir, create_directory, version, verbose)
 
     def load_from_repository(self, version, verbose):
+        if self.opscenter is not None:
+            odir = repository.setup_opscenter(self.opscenter, verbose)
+            target_dir = os.path.join(self.get_path(), 'opscenter')
+            shutil.copytree(odir, target_dir)
         return repository.setup_dse(version, self.dse_username, self.dse_password, verbose)
+
+    def hasOpscenter(self):
+        return os.path.exists(os.path.join(self.get_path(), 'opscenter'))
 
     def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None):
         return DseNode(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface)
+
+    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=[], profile_options=None):
+        started = super(DseCluster, self).start(no_wait, verbose, wait_for_binary_proto, wait_other_notice, jvm_args, profile_options)
+        self.start_opscenter()
+        return started
+
+    def stop(self, wait=True, gently=True):
+        not_running = super(DseCluster, self).stop(wait, gently)
+        self.stop_opscenter()
+        return not_running
 
     def cassandra_version(self):
         return common.get_dse_cassandra_version(self.get_install_dir())
@@ -30,3 +52,37 @@ class DseCluster(Cluster):
             node.import_dse_config_files()
         return self
 
+    def start_opscenter(self):
+        if self.hasOpscenter():
+            self.write_opscenter_cluster_config()
+            args = [os.path.join(self.get_path(), 'opscenter', 'bin', common.platform_binary('opscenter'))]
+            subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    def stop_opscenter(self):
+        pidfile = os.path.join(self.get_path(), 'opscenter', 'twistd.pid')
+        if os.path.exists(pidfile):
+            with open(pidfile, 'r') as f:
+                pid = int(f.readline().strip())
+                f.close()
+            if pid is not None:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except OSError:
+                    pass
+            os.remove(pidfile)
+
+    def write_opscenter_cluster_config(self):
+        cluster_conf = os.path.join(self.get_path(), 'opscenter', 'conf', 'clusters')
+        if not os.path.exists(cluster_conf):
+            os.makedirs(cluster_conf)
+            if len(self.seeds) > 0:
+                seed = self.seeds[0]
+                (seed_ip, seed_port) = seed.network_interfaces['thrift']
+                seed_jmx = seed.jmx_port
+                with open(os.path.join(cluster_conf, self.name + '.conf'), 'w+') as f:
+                    f.write('[jmx]\n')
+                    f.write('port = %s\n' % seed_jmx)
+                    f.write('[cassandra]\n')
+                    f.write('seed_hosts = %s\n' % seed_ip)
+                    f.write('api_port = %s\n' % seed_port)
+                    f.close()


### PR DESCRIPTION
This adds the **-o** or **--opsc** option to include opscenter when creating a DSE cluster. This will download and install opscenter and install the agent on each node in the cluster.
