### PR TITLE
Add ignored options to hadoop options

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -619,7 +619,7 @@ class NodeHadoopCmd(Cmd):
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
-        self.hadoop_options = args[1:]
+        self.hadoop_options = args[1:] + parser.get_ignored()
 
     def run(self):
         self.node.hadoop(self.hadoop_options)


### PR DESCRIPTION
This fixes a small bug in the 'ccm <node> hadoop <cmd> <cmd_options> command where the cmd_options were not getting passed through to hadoop.
