### PR TITLE
Added a ccm <node> taillog command

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import tailer
 
 from six import print_
 
@@ -12,6 +13,7 @@ def node_cmds():
         "show",
         "remove",
         "showlog",
+        "taillog",
         "setlog",
         "start",
         "stop",
@@ -88,6 +90,26 @@ class NodeShowlogCmd(Cmd):
         log = self.node.logfilename()
         pager = os.environ.get('PAGER', common.platform_pager())
         os.execvp(pager, (pager, log))
+
+class NodeTaillogCmd(Cmd):
+    def description(self):
+        return "Tail the system.log of node name"
+
+    def get_parser(self):
+        usage = "usage: ccm node_name taillog"
+        return self._get_default_parser(usage, self.description())
+
+    def validate(self, parser, options, args):
+        Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
+
+    def run(self):
+        log = self.node.logfilename()
+        try:
+            for line in tailer.follow(open(log), delay=0.1):
+                print_(line)
+        except KeyboardInterrupt:
+            print_('\n')
+            pass
 
 class NodeSetlogCmd(Cmd):
     def description(self):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     url='https://github.com/pcmanus/ccm',
     packages=['ccmlib', 'ccmlib.cmds'],
     scripts=['ccm'],
-    install_requires=['pyYaml', 'six >=1.4.1'],
+    install_requires=['pyYaml', 'six >=1.4.1', 'tailer'],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",


### PR DESCRIPTION
This is a simple command that simulates what 'tail -f system.log' does but as a ccm command. It saves having to dive into the .ccm folder to find the log file.
