### PR TITLE
Add --no-snapshot option to sstablesplit and improve the support to specify files

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -451,29 +451,33 @@ class NodeSstablesplitCmd(Cmd):
                           help="Comma seperated list of column families ut use (requires -k to be set)")
         parser.add_option('-s', '--size', type='int', dest="size", default=None,
                           help="Maximum size in MB for the output sstables (default: 50 MB)")
+        parser.add_option('--no-snapshot', action='store_true', dest="no_snapshot", default=False,
+                          help="Don't snapshot the sstables before splitting")
         return parser
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
         self.keyspace = options.keyspace
         self.size = options.size
+        self.no_snapshot = options.no_snapshot
         self.column_families = None
-        self.datafile = None
+        self.datafiles = None
+        if options.cfs is not None:
+            if self.keyspace is None:
+                print_("You need a keyspace (option -k) if you specify column families", file=sys.stderr)
+                exit(1)
+            self.column_families = options.cfs.split(',')
 
         if len(args) > 1:
-            self.datafile = args[1]
-        else:
-            if options.cfs is not None:
-                if self.keyspace is None:
-                    print_("You need a keyspace (option -k) if you specify column families", file=sys.stderr)
-                    exit(1)
-                    self.column_families = options.cfs.split(',')
+            if self.column_families is None:
+                print_("You need a column family (option -c) if you specify datafiles", file=sys.stderr)
+                exit(1)
+            self.datafiles = args[1:]
 
     def run(self):
-        if self.datafile is not None:
-            self.node.run_sstablesplit(datafile=self.datafile, size=self.size)
-        else:
-            self.node.run_sstablesplit(keyspace=self.keyspace, column_families=self.column_families, size=self.size)
+        self.node.run_sstablesplit(datafiles=self.datafiles, keyspace=self.keyspace,
+                                   column_families=self.column_families, size=self.size,
+                                   no_snapshot=self.no_snapshot)
 
 class NodeUpdateconfCmd(Cmd):
     def description(self):


### PR DESCRIPTION
This PR contains some improvements for the sstablesplit command:

* Add --no-snapshot option
* Add the capability to specify what file(s) to split. This was broken before and it was splitting all sstables everytime. I fixed this so we can now specify 1 or more files to split.
* This doesn't affect sstable2json, this command doesn't accept sstable file(s) in parameter.
* The only thing that could affect dtests would have been the parameter name change (datafile -> datafiles). I verified and it is not used at all in dtest.