### PR TITLE
stress command: Forward extra kwargs to subprocess.call

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -860,7 +860,7 @@ class Node(object):
                 files.remove(f)
         return files
 
-    def stress(self, stress_options=[]):
+    def stress(self, stress_options=[], **kwargs):
         stress = common.get_stress_bin(self.get_install_dir())
         if self.cluster.cassandra_version() <= '2.1':
             stress_options.append('-d')
@@ -870,7 +870,7 @@ class Node(object):
             stress_options.append(self.address())
         args = [ stress ] + stress_options
         try:
-            subprocess.call(args, cwd=common.parse_path(stress))
+            subprocess.call(args, cwd=common.parse_path(stress), **kwargs)
         except KeyboardInterrupt:
             pass
 


### PR DESCRIPTION
Useful if we expect a stress command to fail, and want to ignore the 1000+ lines of errors. 