### PR TITLE
Use a larger offset for multi-DC tokens.

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -186,12 +186,12 @@ class Cluster(object):
             if dc == current_dc:
                 count += 1
             else:
-                new_tokens = [tk+dc_count for tk in self.balanced_tokens(count)]
+                new_tokens = [tk+(dc_count*100) for tk in self.balanced_tokens(count)]
                 tokens.extend(new_tokens)
                 current_dc = dc
                 count = 1
                 dc_count += 1
-        new_tokens = [tk+dc_count for tk in self.balanced_tokens(count)]
+        new_tokens = [tk+(dc_count*100) for tk in self.balanced_tokens(count)]
         tokens.extend(new_tokens)
         return tokens
 


### PR DESCRIPTION
Bumps DC token offsets from 1 to 100, this allows for better support of bootstrapping a node without an initial_token and for replacing a dead node.

I encountered an issue while creating a cluster with 2 datacenters with 2 nodes in each and then bootstrapping a new node in the 2nd datacenter:

    ccm create test12192 -n 2:2 -s -v 1.2.19
    ccm add node5 -i 127.0.0.5 -j 7500 -b -d dc2
    ccm node5 start --wait-other-notice --wait-for-binary-proto

This will fail inconsistently depending on what node is chosen to generate the token to bootstrap the node with.   node5 will fail to bootstrap if it tries to acquire a token from node3 since node3 takes the midpoint of it's range (`-9223372036854775807..-9223372036854775808`) which returns the token for node0 (`-9223372036854775808`) given the ring configuration of:

    Datacenter: dc1
    ==========
    Replicas: 1
    
    Address    Rack        Status State   Load            Owns                Token
                                                                              0
    127.0.0.1  r1          Up     Normal  50.93 KB        50.00%              -9223372036854775808
    127.0.0.2  r1          Up     Normal  65.39 KB        50.00%              0
    
    Datacenter: dc2
    ==========
    Replicas: 0
    
    Address    Rack        Status State   Load            Owns                Token
                                                                              1
    127.0.0.3  r1          Up     Normal  40.7 KB         0.00%               -9223372036854775807
    127.0.0.4  r1          Up     Normal  50.91 KB        0.00%               1

Error from node3 system.log:

    ERROR [MiscStage:1] 2015-02-12 14:55:06,822 CassandraDaemon.java (line 191) Exception in thread Thread[MiscStage:1,5,main]
    java.lang.RuntimeException: Chose token -9223372036854775808 which is already in use by /127.0.0.1 -- specify one manually with initial_token
            at org.apache.cassandra.service.StorageService.getBootstrapToken(StorageService.java:2804)
            at org.apache.cassandra.dht.BootStrapper$BootstrapTokenVerbHandler.doVerb(BootStrapper.java:211)
            at org.apache.cassandra.net.MessageDeliveryTask.run(MessageDeliveryTask.java:56)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
            at java.lang.Thread.run(Thread.java:745)

Output from adding node:

    java.lang.RuntimeException: Bootstrap failed, could not obtain token from: /127.0.0.3
     	at org.apache.cassandra.dht.BootStrapper.getBootstrapTokenFrom(BootStrapper.java:202)
    	at org.apache.cassandra.dht.BootStrapper.getBalancedToken(BootStrapper.java:136)
    	at org.apache.cassandra.dht.BootStrapper.getBootstrapTokens(BootStrapper.java:115)
    	at org.apache.cassandra.service.StorageService.joinTokenRing(StorageService.java:718)
    	at org.apache.cassandra.service.StorageService.initServer(StorageService.java:590)
    	at org.apache.cassandra.service.StorageService.initServer(StorageService.java:479)
    	at org.apache.cassandra.service.CassandraDaemon.setup(CassandraDaemon.java:348)
    	at org.apache.cassandra.service.CassandraDaemon.activate(CassandraDaemon.java:447)
    	at org.apache.cassandra.service.CassandraDaemon.main(CassandraDaemon.java:490)

Changing the offset to 100 (as suggested [here](http://www.datastax.com/docs/1.0/initialize/token_generation#datacenter-tokens)) does the job.  Another alternative would be to alternate the token assignments between datacenters, but this change seems the lower risk and as the comments in #38 suggest this is less of a concern with vnodes becoming more common place.

With this change I'm able to successfully bootstrap a new node:

    Datacenter: dc1
    ==========
    Address    Rack        Status State   Load            Owns                Token                                       
                                                                              0                                           
    127.0.0.1  r1          Up     Normal  14.04 KB        50.00%              -9223372036854775808                        
    127.0.0.2  r1          Up     Normal  14.02 KB        50.00%              0                                           

    Datacenter: dc2
    ==========
    Address    Rack        Status State   Load            Owns                Token                                       
                                                                              100                                         
    127.0.0.5  r1          Up     Normal  10.77 KB        0.00%               -9223372036854775758                        
    127.0.0.3  r1          Up     Normal  14.04 KB        0.00%               -9223372036854775708                        
    127.0.0.4  r1          Up     Normal  14.02 KB        0.00%               100                                         

Not an ideal ring but it works.