### PR TITLE
Fix invalid file permissions for running sstable related commands

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -531,9 +531,9 @@ class ClusterStopCmd(Cmd):
         try:
             not_running = self.cluster.stop(not self.options.no_wait, gently=self.options.gently)
             if self.options.verbose and len(not_running) > 0:
-                sys.out.write("The following nodes were not running: ")
+                sys.stdout.write("The following nodes were not running: ")
                 for node in not_running:
-                    sys.out.write(node.name + " ")
+                    sys.stdout.write(node.name + " ")
                 print_("")
         except NodeError as e:
             print_(str(e), file=sys.stderr)


### PR DESCRIPTION
I had trouble to execute all tools except run_sstable2json(). So I moved the permission checking code from there into a new method find_cmd() which is called by all other run* methods for retrieving the path to the command with fixed permissions. 

**Edit:** PR has been rebased onto develop as requested. Please be aware that I haven't tested this against develop yet (will do next week).