### PR TITLE
uses `nodetool info` to get node's data size

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -4,6 +4,7 @@ from __future__ import with_statement
 from six import print_, iteritems, string_types
 from six.moves import xrange
 
+import decimal
 import errno
 import glob
 import os
@@ -14,6 +15,7 @@ import stat
 import subprocess
 import sys
 import time
+import warnings
 import yaml
 import shlex
 
@@ -882,16 +884,13 @@ class Node(object):
         except KeyboardInterrupt:
             pass
 
-    def data_size(self, live_data=True):
-        size = 0
-        if live_data:
-            for ks in self.list_keyspaces():
-                size += sum((os.path.getsize(path) for path in self.get_sstables(ks, "")))
-        else:
-            for ks in self.list_keyspaces():
-                for root, dirs, files in os.walk(os.path.join(self.get_path(), 'data', ks)):
-                    size += sum((os.path.getsize(os.path.join(root, f)) for f in files if os.path.isfile(os.path.join(root, f))))
-        return size
+    def data_size(self, live_data=None):
+        """Uses `nodetool info` to get the size of a node's data in KB."""
+        if live_data is not None:
+            warnings.warn("The 'live_data' keyword argument is deprecated.",
+                          DeprecationWarning)
+        info = self.nodetool('info', capture_output=True)[0]
+        return _get_load_from_info_output(info)
 
     def flush(self):
         self.nodetool("flush")
@@ -1351,3 +1350,31 @@ class Node(object):
 
     def resume(self):
         os.kill(self.pid, signal.SIGCONT)
+
+def _get_load_from_info_output(info):
+    load_lines = [s for s in info.split('\n')
+                    if s.startswith('Load')]
+    if not len(load_lines) == 1:
+        msg = ('Expected output from `nodetool info` to contain exactly 1 '
+                'line starting with "Load". Found:\n') + info
+        raise RuntimeError(msg)
+    load_line = load_lines[0].split()
+
+    unit_multipliers = {'KB': 1,
+                        'MB': 1024,
+                        'GB': 1024 * 1024,
+                        'TB': 1024 * 1024 * 1024}
+    load_num, load_units = load_line[2], load_line[3]
+
+    try:
+        load_mult = unit_multipliers[load_units]
+    except KeyError:
+        expected = ', '.join(list(unit_multipliers))
+        msg = ('Expected `nodetool info` to report load in one of the '
+                'following units:\n'
+                '    {expected}\n'
+                'Found:\n'
+                '    {found}').format(expected=expected, found=load_units)
+        raise RuntimeError(msg)
+
+    return decimal.Decimal(load_num) * load_mult

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,9 +1,12 @@
 import sys
 sys.path = [".."] + sys.path
 
+import decimal
+
 from . import TEST_DIR
 from . import ccmtest
 from ccmlib.cluster import Cluster
+import ccmlib
 
 CLUSTER_PATH = TEST_DIR
 
@@ -100,3 +103,48 @@ class TestCCMLib(ccmtest.Tester):
 
         self.cluster.clear()
         self.cluster.stop()
+
+class TestNodeLoad(ccmtest.Tester):
+    def test_rejects_multiple_load_lines(self):
+        info = 'Load : 699 KB\nLoad : 35 GB'
+        with self.assertRaises(RuntimeError):
+            ccmlib.node._get_load_from_info_output(info)
+
+    def test_rejects_unexpected_units(self):
+        infos = ['Load : 200 PB', 'Load : 12 Parsecs']
+
+        for info in infos:
+            with self.assertRaises(RuntimeError):
+                ccmlib.node._get_load_from_info_output(info)
+
+    def test_gets_correct_value(self):
+        info_value = [('Load : 328.45 KB', decimal.Decimal('328.45')),
+                      ('Load : 295.72 MB', decimal.Decimal('295.72') * 1024),
+                      ('Load : 183.79 GB',
+                       decimal.Decimal('183.79') * 1024 * 1024),
+                      ('Load : 82.333 TB',
+                       decimal.Decimal('82.333') * 1024 * 1024 * 1024)]
+
+        for info, value in info_value:
+            self.assertEqual(ccmlib.node._get_load_from_info_output(info),
+                             value)
+
+    def test_with_full_info_output(self):
+        data = ('ID                     : 82800bf3-8c1a-4355-9b72-e19aa61d9fba\n'
+                'Gossip active          : true\n'
+                'Thrift active          : true\n'
+                'Native Transport active: true\n'
+                'Load                   : 247.59 MB\n'
+                'Generation No          : 1426190195\n'
+                'Uptime (seconds)       : 526\n'
+                'Heap Memory (MB)       : 222.83 / 495.00\n'
+                'Off Heap Memory (MB)   : 1.16\n'
+                'Data Center            : dc1\n'
+                'Rack                   : r1\n'
+                'Exceptions             : 0\n'
+                'Key Cache              : entries 41, size 3.16 KB, capacity 24 MB, 19 hits, 59 requests, 0.322 recent hit rate, 14400 save period in seconds\n'
+                'Row Cache              : entries 0, size 0 bytes, capacity 0 bytes, 0 hits, 0 requests, NaN recent hit rate, 0 save period in seconds\n'
+                'Counter Cache          : entries 0, size 0 bytes, capacity 12 MB, 0 hits, 0 requests, NaN recent hit rate, 7200 save period in seconds\n'
+                'Token                  : -9223372036854775808\n')
+        self.assertEqual(ccmlib.node._get_load_from_info_output(data),
+                         decimal.Decimal('247.59') * 1024)


### PR DESCRIPTION
as discussed in #245.

Presumably we should remove the deprecation warning at some point. Shall we start a major-version milestone list or something?