### PR TITLE
Don't ever poll process on windows 

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -378,9 +378,13 @@ class Node(object):
                         raise TimeoutError(time.strftime("%d %b %Y %H:%M:%S", time.gmtime()) + " [" + self.name + "] Missing: " + str([e.pattern for e in tofind]) + ":\n" + reads)
 
                 if process:
-                    process.poll()
-                    if process.returncode is not None and process.returncode == 0:
-                        return None
+                    if common.is_win():
+                        if not self.is_running():
+                            return None
+                    else:
+                        process.poll()
+                        if process.returncode == 0:
+                            return None
 
     def watch_log_for_death(self, nodes, from_mark=None, timeout=600):
         """


### PR DESCRIPTION
Fixes #248.

This change relies on the major assumption that we never call `watch_log_for` on a node whose pid we do not know. It also hopes the user has the optional `psutil` dependency installed. `psutil` is optional because it is only required for Windows, and installation via `pip` is problematic, so users must install via the .msi on PyPI. This will make log parsing noticeably slower if `psutil` is not installed.

This PR hopes to solve the issue where with C* 2.1+ on Windows, when not running with legacy startup, the batch script that starts C* returns with exit code zero as soon as the Cassandra Daemon has started up. Thus, the log parsing will exit early, unless the sought after log line is found in the small window where the batch file is still alive.

I have noticed no change in dtest behavior on Linux or Windows, C* 2.0 or 2.1 using this PR. Pointing this at master, as it is a bugfix preventing use of CCM on Windows for some users.

@jorgebay Can you confirm you no longer run into your issue with this PR?
@EnigmaCurry for review.