### PR TITLE
Fix nodetool options which are not passed

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -224,20 +224,6 @@ class _NodeToolCmd(Cmd):
     def run(self):
         self.node.nodetool(self.nodetool_cmd)
 
-class _NodeToolCmd(Cmd):
-    def get_parser(self):
-        parser = self._get_default_parser(self.usage, self.description())
-        return parser
-
-    def description(self):
-        return self.descr_text
-
-    def validate(self, parser, options, args):
-        Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
-
-    def run(self):
-        self.node.nodetool(self.nodetool_cmd)
-
 class NodeNodetoolCmd(_NodeToolCmd):
     usage = "usage: ccm node_name nodetool [options]"
     descr_text = "Run nodetool (connecting to node name)"

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -222,7 +222,7 @@ class _NodeToolCmd(Cmd):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
 
     def run(self):
-        self.node.nodetool(self.nodetool_cmd)
+        self.node.nodetool(self.nodetool_cmd + " " + " ".join((self.args[1:])))
 
 class NodeNodetoolCmd(_NodeToolCmd):
     usage = "usage: ccm node_name nodetool [options]"


### PR DESCRIPTION
By typing the command below, we can see that the keyspace argument is not taken into account (there is a Note on the beginning of the output of the command):
ccm node1 ring myKS

This pull request allows to pass the options of nodetool commands

