### PR TITLE
`run_cqlsh` improvements

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -695,7 +695,9 @@ class Node(object):
         else:
             p = subprocess.Popen([cqlsh] + args, env=env, stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
             for cmd in cmds.split(';'):
-                p.stdin.write(cmd + ';\n')
+                cmd = cmd.strip()
+                if cmd:
+                    p.stdin.write(cmd + ';\n')
             p.stdin.write("quit;\n")
             p.wait()
             for err in p.stderr:

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -703,12 +703,8 @@ class Node(object):
             for err in p.stderr:
                 print_("(EE) ", err, end='')
             if show_output:
-                i = 0
                 for log in p.stdout:
-                    # first four lines are not interesting
-                    if i >= 4:
-                        print_(log, end='')
-                    i = i + 1
+                    print_(log, end='')
 
     def cli(self):
         cdir = self.get_install_dir()

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1,7 +1,7 @@
 # ccm node
 from __future__ import with_statement
 
-from six import print_, iteritems, string_types
+from six import print_, iteritems, string_types, StringIO
 from six.moves import xrange
 
 from datetime import datetime
@@ -677,7 +677,7 @@ class Node(object):
                         print_(log, end='')
                     i = i + 1
 
-    def run_cqlsh(self, cmds=None, show_output=False, cqlsh_options=[]):
+    def run_cqlsh(self, cmds=None, show_output=False, cqlsh_options=[], return_output=False):
         cqlsh = self.get_tool('cqlsh')
         env = common.make_cassandra_env(self.get_install_cassandra_root(), self.get_node_cassandra_root())
         host = self.network_interfaces['thrift'][0]
@@ -702,9 +702,14 @@ class Node(object):
             p.wait()
             for err in p.stderr:
                 print_("(EE) ", err, end='')
+
+            output = (p.stdout.read(), p.stderr.read())
+
             if show_output:
-                for log in p.stdout:
-                    print_(log, end='')
+                print_(output[0], end='')
+
+            if return_output:
+                return output
 
     def cli(self):
         cdir = self.get_install_dir()


### PR DESCRIPTION
Several improvements here:

- The way `Node.run_cqlsh` split its input led to lots of lines that looked like `';\n'` getting sent to cqlsh, which leads to confusing syntax errors. This only sends `line + ';'` if `line.strip()` is non-empty.
- If the `show_output` kwarg to `run_cqlsh` is truthy, it prints all output. However, it skipped the first 4 lines. This may have been getting around some property of an old cqlsh, but this is no longer valid.
- Finally, this adds a `return_output` kwarg. If it's truthy, `run_cqlsh` will return cqlsh's output as a string.

Since `return_output` is a kwarg with a default value at the end of the argument list, this shouldn't change the `run_cqlsh` API; if you just ignore it, it won't affect you.

 I've also tested the combination of these two kwargs and added a basic "does this thing fall over" test.