### PR TITLE
fixes stderr handling in run_cqlsh

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -677,10 +677,11 @@ class Node(object):
                     p.stdin.write(cmd + ';\n')
             p.stdin.write("quit;\n")
             p.wait()
-            for err in p.stderr:
-                print_("(EE) ", err, end='')
 
             output = (p.stdout.read(), p.stderr.read())
+
+            for err in output[1].split('\n'):
+                print_("(EE) ", err, end='')
 
             if show_output:
                 print_(output[0], end='')


### PR DESCRIPTION
Before, p.stderr was consumed printing each line, which meant that p.stderr.read() always returned an empty string. Now, stdout and stderr are flattened to strings before being processed and/or returned.