### PR TITLE
278

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -135,7 +135,8 @@ def make_cassandra_env(install_dir, node_path):
         sh_file = os.path.join(BIN_DIR, CASSANDRA_SH)
     orig = os.path.join(install_dir, sh_file)
     dst = os.path.join(node_path, sh_file)
-    shutil.copy(orig, dst)
+    if not os.path.exists(dst):
+        shutil.copy(orig, dst)
     replacements = ""
     if is_win() and get_version_from_build(node_path=node_path) >= '2.1':
         replacements = [

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1124,16 +1124,20 @@ class Node(object):
 
     def __update_envfile(self):
         if common.is_win():
-            jmx_port_pattern = '^\s+\$JMX_PORT='
             conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_WIN_ENV)
+            jmx_port_pattern = '^\s+\$JMX_PORT='
+            jmx_port_setting = '    $JMX_PORT="' + self.jmx_port + '"'
             remote_debug_options = '    $env:JVM_OPTS="$env:JVM_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=' + str(self.remote_debug_port) + '"'
         else:
-            jmx_port_pattern = 'JMX_PORT='
             conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_ENV)
+            jmx_port_pattern = 'JMX_PORT='
+            jmx_port_setting = 'JMX_PORT="' + self.jmx_port + '"'
             remote_debug_options = 'JVM_OPTS="$JVM_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=' + str(self.remote_debug_port) + '"'
-        remote_debug_port_pattern = '((-Xrunjdwp:)|(-agentlib:jdwp=))transport=dt_socket,server=y,suspend=n,address='
-        common.replace_in_file(conf_file, jmx_port_pattern, jmx_port_pattern + self.jmx_port)
+
+        common.replace_in_file(conf_file, jmx_port_pattern, jmx_port_setting)
+
         if self.remote_debug_port != '0':
+            remote_debug_port_pattern = '((-Xrunjdwp:)|(-agentlib:jdwp=))transport=dt_socket,server=y,suspend=n,address='
             common.replace_in_file(conf_file, remote_debug_port_pattern, remote_debug_options)
 
         if self.get_cassandra_version() < '2.0.1':


### PR DESCRIPTION
The patch make sure that we do not overrides the configuration files in  common.make_cassandra_env and fix the wrong JMX configuration that was made for Windows in node.__update_envfile.