### PR TITLE
fix data directory globbing in Node.get_sstable

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -840,7 +840,11 @@ class Node(object):
         keyspace_dir = os.path.join(self.get_path(), 'data', keyspace)
         cf_glob = '*'
         if column_family:
-            cf_glob = column_family + '-*'
+            # account for changes in data dir layout from CASSANDRA-5202
+            if self.get_base_cassandra_version() < 2.1:
+                cf_glob = column_family
+            else:
+                cf_glob = column_family + '-*'
         if not os.path.exists(keyspace_dir):
             raise common.ArgumentError("Unknown keyspace {0}".format(keyspace))
 


### PR DESCRIPTION
The only thing I did to verify this change was to run the dtest mentioned [here](https://github.com/riptano/cassandra-dtest/pull/272) on 2.0, 2.1, and trunk:

```
set -x

for v in git:cassandra-2.0 git:cassandra-2.1 git:trunk ; do
  CASSANDRA_VERSION=$v nosetests compaction_test.py:TestCompaction_with_DateTieredCompactionStrategy.dtcs_deletion_test
done
```

It fails on 2.0 without this change, and succeeds on all branches with it. So, the reviewer should keep in mind it's not tested very extensively.