### PR TITLE
Fix node.get_sstables() for Cassandra 2.2

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -851,7 +851,7 @@ class Node(object):
         # data directory layout is changed from 1.1
         if self.get_base_cassandra_version() < 1.1:
             files = glob.glob(os.path.join(keyspace_dir, "{0}*-Data.db".format(column_family)))
-        elif self.get_base_cassandra_version() < 3.0:
+        elif self.get_base_cassandra_version() < 2.2:
             files = glob.glob(os.path.join(keyspace_dir, cf_glob, "%s-%s*-Data.db" % (keyspace, column_family)))
         else:
             files = glob.glob(os.path.join(keyspace_dir, cf_glob, "*big-Data.db"))


### PR DESCRIPTION
This should fix the new dtest failures