### PR TITLE
Revise default startup string watched for in cluster.start for 2.2+

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -254,7 +254,8 @@ class Cluster(object):
         else:
             for node, p, mark in started:
                 try:
-                    node.watch_log_for("Listening for thrift clients...", process=p, verbose=verbose, from_mark=mark)
+                    start_message = "Listening for thrift clients..." if self.cassandra_version() < "2.2" else "Starting listening for CQL clients"
+                    node.watch_log_for(start_message, timeout=60, process=p, verbose=verbose, from_mark=mark)
                 except RuntimeError:
                     return None
 


### PR DESCRIPTION
Also added 60 second timeout on watching startup instead of default 10 minutes