### PR TITLE
Print pid of nodes when started on Windows

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -508,6 +508,7 @@ class Node(object):
         if common.is_win():
             self.__clean_win_pid()
             self._update_pid(process)
+            print_("Started: {0} with pid: {1}".format(self.name, self.pid), file=sys.stderr, flush=True)
         elif update_pid:
             self._update_pid(process)
 


### PR DESCRIPTION
This is an interim change to facilitate tracking down if specific dtests are consistently hanging. Windows only and just a little verbosity on node start.