### PR TITLE
Improve behavior of wait_other_notice in cluster.start()

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -237,7 +237,7 @@ class Cluster(object):
 
     def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=[], profile_options=None):
         if wait_other_notice:
-            marks = [ (node, node.mark_log()) for node in list(self.nodes.values()) if node.is_running() ]
+            marks = [(node, node.mark_log()) for node in list(self.nodes.values())]
 
         started = []
         for node in list(self.nodes.values()):
@@ -276,7 +276,8 @@ class Cluster(object):
         if wait_other_notice:
             for old_node, mark in marks:
                 for node, _, _ in started:
-                    old_node.watch_log_for_alive(node, from_mark=mark)
+                    if old_node is not node:
+                        old_node.watch_log_for_alive(node, from_mark=mark)
 
         if wait_for_binary_proto and self.version() >= '1.2':
             for node, _, mark in started:


### PR DESCRIPTION
Normally when cluster.start() is called, none of the nodes are running,
so we wouldn't collect marks for any nodes, resulting in the later log
check doing nothing.  Instead, we can collect marks for any node and
then just make sure we don't watch a node's log for itself.