### PR TITLE
rmdir() to allow rmtree on path > 255 chars on Windows

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -57,7 +57,7 @@ class Cluster(object):
                 self._update_config()
         except:
             if create_directory:
-                shutil.rmtree(self.get_path())
+                common.rmdirs(self.get_path())
             raise
 
     def load_from_repository(self, version, verbose):
@@ -205,10 +205,10 @@ class Cluster(object):
                 self.seeds.remove(node)
             self._update_config()
             node.stop(gently=False)
-            shutil.rmtree(node.get_path())
+            common.rmdirs(node.get_path())
         else:
             self.stop(gently=False)
-            shutil.rmtree(self.get_path())
+            common.rmdirs(self.get_path())
 
     def clear(self):
         self.stop()

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -128,6 +128,13 @@ def replaces_or_add_into_file_tail(file, replacement_list):
 
     shutil.move(file_tmp, file)
 
+def rmdirs(path):
+    if is_win():
+        # Handle Windows 255 char limit
+        shutil.rmtree(u"\\\\?\\" + path)
+    else:
+        shutil.rmtree(path)
+
 def make_cassandra_env(install_dir, node_path):
     if is_win() and get_version_from_build(node_path=node_path) >= '2.1':
         sh_file = os.path.join(CASSANDRA_CONF_DIR, CASSANDRA_WIN_ENV)
@@ -472,4 +479,4 @@ def is_dse_cluster(path):
         return False
 
 def invalidate_cache():
-    shutil.rmtree(os.path.join(get_default_path(), 'repository'))
+    rmdirs(os.path.join(get_default_path(), 'repository'))

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -263,24 +263,24 @@ class DseNode(Node):
             src_conf = os.path.join(self.get_install_dir(), 'resources', product, 'conf')
             dst_conf = os.path.join(self.get_path(), 'resources', product, 'conf')
             if os.path.isdir(dst_conf):
-                shutil.rmtree(dst_conf)
+                common.rmdirs(dst_conf)
             shutil.copytree(src_conf, dst_conf)
             if product == 'solr':
                 src_web = os.path.join(self.get_install_dir(), 'resources', product, 'web')
                 dst_web = os.path.join(self.get_path(), 'resources', product, 'web')
                 if os.path.isdir(dst_web):
-                    shutil.rmtree(dst_web)
+                    common.rmdirs(dst_web)
                 shutil.copytree(src_web, dst_web)
             if product == 'tomcat':
                 src_lib = os.path.join(self.get_install_dir(), 'resources', product, 'lib')
                 dst_lib = os.path.join(self.get_path(), 'resources', product, 'lib')
                 if os.path.isdir(dst_lib):
-                    shutil.rmtree(dst_lib)
+                    common.rmdirs(dst_lib)
                 shutil.copytree(src_lib, dst_lib)
                 src_webapps = os.path.join(self.get_install_dir(), 'resources', product, 'webapps')
                 dst_webapps = os.path.join(self.get_path(), 'resources', product, 'webapps')
                 if os.path.isdir(dst_webapps):
-                    shutil.rmtree(dst_webapps)
+                    common.rmdirs(dst_webapps)
                 shutil.copytree(src_webapps, dst_webapps)
 
     def import_bin_files(self):

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -744,7 +744,7 @@ class Node(object):
                             if os.path.isfile(full_path):
                                 os.remove(full_path)
             else:
-                shutil.rmtree(full_dir)
+                common.rmdirs(full_dir)
                 os.mkdir(full_dir)
 
     def run_sstable2json(self, out_file=None, keyspace=None, datafiles=None, column_families=None, enumerate_keys=False):

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -17,7 +17,7 @@ import re
 from distutils.version import LooseVersion
 
 from ccmlib.common import (ArgumentError, CCMError, get_default_path,
-                           platform_binary, validate_install_dir)
+                           platform_binary, validate_install_dir, rmdirs)
 
 DSE_ARCHIVE="http://downloads.datastax.com/enterprise/dse-%s-bin.tar.gz"
 OPSC_ARCHIVE="http://downloads.datastax.com/community/opscenter-%s.tar.gz"
@@ -123,7 +123,7 @@ def clone_development(git_repo, version, verbose=False):
         except:
             # wipe out the directory if anything goes wrong. Otherwise we will assume it has been compiled the next time it runs.
             try:
-                shutil.rmtree(target_dir)
+                rmdirs(target_dir)
                 print_("Deleted %s due to error" % target_dir)
             except:
                 raise CCMError("Building C* version %s failed. Attempted to delete %s but failed. This will need to be manually deleted" % (version, target_dir))
@@ -142,7 +142,7 @@ def download_dse_version(version, username, password, verbose=False):
         tar.close()
         target_dir = os.path.join(__get_dir(), version)
         if os.path.exists(target_dir):
-            shutil.rmtree(target_dir)
+            rmdirs(target_dir)
         shutil.move(os.path.join(__get_dir(), dir), target_dir)
     except urllib.error.URLError as e:
         msg = "Invalid version %s" % version if url is None else "Invalid url %s" % url
@@ -164,7 +164,7 @@ def download_opscenter_version(version, target_version, verbose=False):
         tar.close()
         target_dir = os.path.join(__get_dir(), target_version)
         if os.path.exists(target_dir):
-            shutil.rmtree(target_dir)
+            rmdirs(target_dir)
         shutil.move(os.path.join(__get_dir(), dir), target_dir)
     except urllib.error.URLError as e:
         msg = "Invalid version %s" % version if url is None else "Invalid url %s" % url
@@ -193,7 +193,7 @@ def download_version(version, url=None, verbose=False, binary=False):
         tar.close()
         target_dir = os.path.join(__get_dir(), version)
         if os.path.exists(target_dir):
-            shutil.rmtree(target_dir)
+            rmdirs(target_dir)
         shutil.move(os.path.join(__get_dir(), dir), target_dir)
 
         if binary:
@@ -214,7 +214,7 @@ def download_version(version, url=None, verbose=False, binary=False):
     except CCMError as e:
         # wipe out the directory if anything goes wrong. Otherwise we will assume it has been compiled the next time it runs.
         try:
-            shutil.rmtree(target_dir)
+            rmdirs(target_dir)
             print_("Deleted %s due to error" % target_dir)
         except:
             raise CCMError("Building C* version %s failed. Attempted to delete %s but failed. This will need to be manually deleted" % (version, target_dir))
@@ -273,13 +273,13 @@ def version_directory(version):
             validate_install_dir(dir)
             return dir
         except ArgumentError as e:
-            shutil.rmtree(dir)
+            rmdirs(dir)
             return None
     else:
         return None
 
 def clean_all():
-    shutil.rmtree(__get_dir())
+    rmdirs(__get_dir())
 
 def get_tagged_version_numbers(series='stable'):
     """Retrieve git tags and find version numbers for a release series


### PR DESCRIPTION
Created new helper method common.rmdir() to allow rmtree on path > 255 chars on Windows.