### PR TITLE
Add 'kill' command to SIGKILL a node.

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -47,7 +47,8 @@ def node_cmds():
         "sqoop",
         "spark",
         "pause",
-        "resume"
+        "resume",
+        "kill"
     ]
 
 class NodeShowCmd(Cmd):
@@ -751,3 +752,18 @@ class NodeResumeCmd(Cmd):
 
     def run(self):
         self.node.resume()
+
+class NodeKillCmd(Cmd):
+    def description(self):
+        return "Send a SIGKILL to this node"
+
+    def get_parser(self):
+        usage = "usage: ccm node_name kill"
+        parser = self._get_default_parser(usage, self.description())
+        return parser
+
+    def validate(self, parser, options, args):
+        Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
+
+    def run(self):
+        self.node.kill()

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1452,6 +1452,17 @@ class Node(object):
             else:
                 os.kill(self.pid, signal.SIGCONT)
 
+    def kill(self):
+        try:
+            import psutil
+            p = psutil.Process(self.pid)
+            p.kill()
+        except ImportError:
+            if common.is_win():
+                print_("WARN: psutil not installed.  Kill functionality will not work properly on Windows.")
+            else:
+                os.kill(self.pid, signal.SIGKILL)
+
 def _get_load_from_info_output(info):
     load_lines = [s for s in info.split('\n')
                   if s.startswith('Load')]


### PR DESCRIPTION
For testing, it is useful to be able to send a SIGKILL to a node to have
it uncleanly terminate.  In this case the OS will send TCP RST messages to
clients which may cause them to behave in unpredictable ways.