### PR TITLE
GitHub repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,20 @@ If you'd like to use a binary distribution instead of compiling from sources eac
 ccm create test -v binary:2.0.5 -n 3 -s
 ```
 
+### Git and GitHub
+
+To use the latest version from the [canonical Apache Git repository](https://git-wip-us.apache.org/repos/asf?p=cassandra.git), use the version name `git:branch-name`, e.g.:
+
+```
+ccm create trunk -v git:trunk -n 5
+```
+
+and to download a branch from a GitHub fork of Cassandra, you can prefix the repository and branch with `github:`, e.g.:
+
+```
+ccm create patched -v github:jbellis/trunk -n 1
+```
+
 Remote debugging
 -----------------------
 

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -284,6 +284,9 @@ def github_username_and_branch_name(version):
     assert version.startswith('github')
     return version.split(':', 1)[1].split('/', 1)
 
+def github_repo_for_user(username):
+    return 'git@github.com:{username}/cassandra.git'.format(username=username)
+
 def version_directory(version):
     dir = directory_name(version)
     if os.path.exists(dir):
@@ -382,6 +385,3 @@ def __get_dir():
     if not os.path.exists(repo):
         os.mkdir(repo)
     return repo
-
-def github_repo_for_user(username):
-    return 'git@github.com:{username}/cassandra.git'.format(username=username)

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -34,7 +34,7 @@ def setup(version, verbose=False):
         version = version.replace('binary:','')
         binary = True
     elif version.startswith('github:'):
-        user_name = version.replace('github:', '').split('/', 1)[0]
+        user_name, _ = github_username_and_branch_name(version)
         clone_development(github_repo_for_user(user_name), version, verbose=verbose)
         return (directory_name(version), None)
     if version in ('stable','oldstable','testing'):
@@ -70,7 +70,7 @@ def clone_development(git_repo, version, verbose=False):
     target_dir = directory_name(version)
     assert target_dir
     if 'github' in version:
-        git_repo_name, git_branch = version.split(':', 1)[1].split('/', 1)
+        git_repo_name, git_branch = github_username_and_branch_name(version)
     else:
         git_repo_name = 'apache'
         git_branch = version.split(':', 1)[1]
@@ -279,6 +279,10 @@ def directory_name(version):
     version = version.replace(':', 'COLON') # handle git branches like 'git:trunk'.
     version = version.replace('/', 'SLASH') # handle git branches like 'github:mambocab/trunk'.
     return os.path.join(__get_dir(), version)
+
+def github_username_and_branch_name(version):
+    assert version.startswith('github')
+    return version.split(':', 1)[1].split('/', 1)
 
 def version_directory(version):
     dir = directory_name(version)


### PR DESCRIPTION
Allows for creation of clusters from github by specifying `github:username/branch_name` instead of `git:branch_name`, partially addressing #293.

This is pretty quick-and-dirty, but it seems to work. It creates a new `_git_cache` directory for each GitHub repo cloned, which could get big after a while.

This changes the existing format for cluster repo directories. Instead of replacing `:` with `_`, it replaces `:` with `COLON` and `/` with `SLASH`. Some replacement for the latter is necessary since `/` is valid in branch names, so we may encounter them in GitHub branches. Replacing them both with uppercase ascii gives each a unique replacement and makes it unlikely that directory names will collide. Users will want to run `ccm invalidatecache` after updating.