### PR TITLE
add option to block on the log for Node.drain

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -958,8 +958,11 @@ class Node(object):
     def compact(self):
         self.nodetool("compact")
 
-    def drain(self):
+    def drain(self, block_on_log=False):
+        mark = self.mark_log()
         self.nodetool("drain")
+        if block_on_log:
+            self.watch_log_for("DRAINED", from_mark=mark)
 
     def repair(self, options=[], **kwargs):
         args = ["repair"] + options


### PR DESCRIPTION
I don't know if this goes against some design philosophy for `node.Node`, so I'm just running this up the flagpole. Seems like [this kind of logic](https://github.com/riptano/cassandra-dtest/pull/338/files#diff-abac0928e2a06eb362676fa694227510R122) could be repeated all over the place in dtests, so why not consolidate that all into one place?