### PR TITLE
makes is_win more readable and idiomatic

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -213,7 +213,7 @@ def check_win_requirements():
             sys.exit("ERROR!  64-bit os and 32-bit python distribution found.  ccm requires matching architectures.")
 
 def is_win():
-    return True if sys.platform == "cygwin" or sys.platform == "win32" else False
+    return sys.platform in ("cygwin", "win32")
 
 def is_ps_unrestricted():
     if not is_win():


### PR DESCRIPTION
This is just a little more compact and easy to read. Jankily tested from the interpreter:

```python
>>> from ccmlib import common
>>> import inspect
>>> inspect.getsourcelines(common.is_win)  # check that I'm using my new implementation
(['def is_win():\n', '    return sys.platform in ("cygwin", "win32")\n'], 215)
>>> # I totally am
...
>>> common.is_win()
False
>>> import sys ; sys.platform = 'cygwin'
>>> common.is_win()
True
```