### PR TITLE
Added use of the CCM_CONFIG_DIR environment variable

### DIFF
--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -79,7 +79,7 @@ class Cmd(object):
         else:
             parser = OptionParser(usage=usage, description=description)
         parser.add_option('--config-dir', type="string", dest="config_dir",
-            help="Directory for the cluster files [default to ~/.ccm]")
+            help="Directory for the cluster files [default to {0}]".format(common.get_default_path_display_name()))
         return parser
 
     def description(self):

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -29,6 +29,7 @@ CASSANDRA_WIN_ENV = "cassandra-env.ps1"
 CASSANDRA_SH = "cassandra.in.sh"
 
 CONFIG_FILE = "config"
+CCM_CONFIG_DIR = "CCM_CONFIG_DIR"
 
 class CCMError(Exception):
     pass
@@ -43,9 +44,22 @@ class UnavailableSocketError(CCMError):
     pass
 
 def get_default_path():
-    default_path = os.path.join(get_user_home(), '.ccm')
+    if CCM_CONFIG_DIR in os.environ and os.environ[CCM_CONFIG_DIR]:
+        default_path = os.environ[CCM_CONFIG_DIR]
+    else:
+        default_path = os.path.join(get_user_home(), '.ccm')
+
     if not os.path.exists(default_path):
         os.mkdir(default_path)
+    return default_path
+
+def get_default_path_display_name():
+    default_path = get_default_path().lower()
+    user_home = get_user_home().lower()
+
+    if default_path.startswith(user_home):
+        default_path = os.path.join('~', default_path[len(user_home)+1:])
+
     return default_path
 
 def get_user_home():

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -104,7 +104,7 @@ class DseNode(Node):
         if profile_options is not None:
             config = common.get_config()
             if not 'yourkit_agent' in config:
-                raise NodeError("Cannot enable profile. You need to set 'yourkit_agent' to the path of your agent in a ~/.ccm/config")
+                raise NodeError("Cannot enable profile. You need to set 'yourkit_agent' to the path of your agent in a {0}/config".format(common.get_default_path_display_name()))
             cmd = '-agentpath:%s' % config['yourkit_agent']
             if 'options' in profile_options:
                 cmd = cmd + '=' + profile_options['options']


### PR DESCRIPTION
The value of env var CCM_CONFIG_DIR is used as the config directory instead of ~/.ccm.  If CCM_CONFIG_DIR is not defined or empty, then ~/.ccm is used instead.

This change is useful for me (and hopefullly others) for 2 reasons.

1. My home dir was nearly full and I wanted to put CCM's state on a differencent partition and not have to specify --config-dir on every command.

2. Some data I deal with must be written on an ecrypted filesystem while others do not.

Symlinks/aliases/script/... can handle these issues.  The difference for me is, I set CCM_CONFIG_DIR to a relative path - therefore all my data, code, and ccm state is in one place.

One issue with these changes is the build repository is not shared.  I thought of adding an optional CCM_REPO_DIR env var for this.

I'm a relatively new user to ccm, so I may have overlooked a better way to use ccm.