### PR TITLE
Improvements for updateconf, updatedseconf commands

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -605,7 +605,7 @@ class ClusterUpdateconfCmd(Cmd):
         return "Update the cassandra config files for all nodes"
 
     def get_parser(self):
-        usage = "usage: ccm updateconf [options] [ new_setting | ...  ], where new_setting should be a string of the form 'compaction_throughput_mb_per_sec: 32'"
+        usage = "usage: ccm updateconf [options] [ new_setting | ...  ], where new_setting should be a string of the form 'compaction_throughput_mb_per_sec: 32'; nested options can be separated with a period like 'client_encryption_options.enabled: false'"
         parser = self._get_default_parser(usage, self.description())
         parser.add_option('--no-hh', '--no-hinted-handoff', action="store_false",
             dest="hinted_handoff", default=True, help="Disable hinted handoff")
@@ -643,9 +643,8 @@ class ClusterUpdatedseconfCmd(Cmd):
         return "Update the dse config files for all nodes"
 
     def get_parser(self):
-        usage = "usage: ccm updatedseconf [options] [ new_setting | ...  ], where new_setting should be a string of the form 'max_solr_concurrency_per_core: 2'"
+        usage = "usage: ccm updatedseconf [options] [ new_setting | ...  ], where new_setting should be a string of the form 'max_solr_concurrency_per_core: 2'; nested options can be separated with a period like 'cql_slow_log_options.enabled: true'"
         parser = self._get_default_parser(usage, self.description())
-        parser.add_option('-y', '--yaml', action="store", type="string", dest="yaml_file", help="Path to a yaml file containing options to be copied into each node's dse.yaml. Useful for defining nested structures.", default=None)
         return parser
 
     def validate(self, parser, options, args):
@@ -656,15 +655,7 @@ class ClusterUpdatedseconfCmd(Cmd):
             print_(str(e), file=sys.stderr)
             exit(1)
 
-        if self.options.yaml_file is not None:
-            if not os.path.exists(self.options.yaml_file):
-                print_("%s does not appear to be a valid file" % self.options.yaml_file)
-                exit(1)
-
     def run(self):
-        if self.options.yaml_file is not None:
-            self.setting["dse_yaml_file"] = self.options.yaml_file
-
         self.cluster.set_dse_configuration_options(values=self.setting)
 
 #

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -299,11 +299,11 @@ class DseNode(Node):
         full_options = dict(list(self.cluster._dse_config_options.items()))
         for name in full_options:
             value = full_options[name]
-            if value is None:
+            if type(value) is str and (value is None or len(value) == 0):
                 try:
                     del data[name]
                 except KeyError:
-                    # it is fine to remove a key not there:w
+                    # it is fine to remove a key not there
                     pass
             else:
                 data[name] = full_options[name]

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -298,21 +298,15 @@ class DseNode(Node):
 
         full_options = dict(list(self.cluster._dse_config_options.items()))
         for name in full_options:
-            if not name is 'dse_yaml_file':
-                value = full_options[name]
-                if value is None:
-                    try:
-                        del data[name]
-                    except KeyError:
-                        # it is fine to remove a key not there:w
-                        pass
-                else:
-                    data[name] = full_options[name]
-
-        if 'dse_yaml_file' in full_options:
-            with open(full_options['dse_yaml_file'], 'r') as f:
-                user_yaml = yaml.load(f)
-                data = common.yaml_merge(data, user_yaml)
+            value = full_options[name]
+            if value is None:
+                try:
+                    del data[name]
+                except KeyError:
+                    # it is fine to remove a key not there:w
+                    pass
+            else:
+                data[name] = full_options[name]
 
         with open(conf_file, 'w') as f:
             yaml.safe_dump(data, f, default_flow_style=False)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1128,11 +1128,11 @@ class Node(object):
         full_options = dict(list(self.cluster._config_options.items()) + list(self.__config_options.items())) # last win and we want node options to win
         for name in full_options:
             value = full_options[name]
-            if value is None:
+            if type(value) is str and (value is None or len(value) == 0):
                 try:
                     del data[name]
                 except KeyError:
-                    # it is fine to remove a key not there:w
+                    # it is fine to remove a key not there
                     pass
             else:
                 try:


### PR DESCRIPTION
Changes:
- Remove leftover references to dse_yaml_file option which is no longer supported
- Explain how to specify option.suboption with period separator
- Fix for delete conf setting by not providing the value (ex: "ccm updateconf key:")

I made the 3rd item a separate commit to make the fix more clear.