### PR TITLE
allow ccm to run with ant installed from chocolatey package manager

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -217,9 +217,9 @@ def check_win_requirements():
     if is_win():
         # Make sure ant.bat is in the path and executable before continuing
         try:
-            process = subprocess.Popen('ant.bat', stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            process = subprocess.Popen(platform_binary("ant"), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         except Exception as e:
-            sys.exit("ERROR!  Could not find or execute ant.bat.  Please fix this before attempting to run ccm on Windows.")
+            sys.exit("ERROR!  Could not find or execute ant.  Please fix this before attempting to run ccm on Windows.")
 
         # Confirm matching architectures
         # 32-bit python distributions will launch 32-bit cmd environments, losing PowerShell execution privileges on a 64-bit system
@@ -246,7 +246,7 @@ def join_bin(root, dir, executable):
     return os.path.join(root, dir, platform_binary(executable))
 
 def platform_binary(input):
-    return input + ".bat" if is_win() else input
+    return input + ".bat" if is_win() and not ".bat" in os.environ["PATHEXT"].lower() else input
 
 def platform_pager():
     return "more" if sys.platform == "win32" else "less"


### PR DESCRIPTION
for some reason, the chocolatey package manager on windows installs ANT with the executable ant.exe instead of ant.bat, so ccm is not working because it expects an ant.bat executable. a simple fix is to omit the file extension on windows, which is currently hard-coded to .bat.

on windows7+, if the $PATHEXT variable is set, we can safely ommit the executable extensions listed on that variable while running an executable, so for example, we can run just ant instead of ant.bat.

since ".exe" and ".bat" are listed by default on $PATHEXT we can safely omit the ".bat" extension on ccmlib.common.platform_binary for windows hosts, if .bat is listed in this $PATHEXT variable. if this variable is not set, we still add the .bat suffix to windows binaries, so we maintaint backwards compatibility.