### PR TITLE
makes getsstables print files on separate lines

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -510,7 +510,7 @@ class NodeGetsstablesCmd(Cmd):
     def run(self):
         sstablefiles = self.node.get_sstablespath(datafiles=self.datafiles, keyspace=self.keyspace,
                                    tables=self.tables)
-        print_(sstablefiles)
+        print_('\n'.join(sstablefiles))
 
 class NodeUpdateconfCmd(Cmd):
     def description(self):


### PR DESCRIPTION
Currently `getsstables` prints the sstables formatted as a Python list of strings. This change prints them out without quotes, separated by newlines, so it's easier for unixy things to consume.