### PR TITLE
Establish socket to binary port for --wait-for-binary-proto to ensure port is listening.

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -291,10 +291,9 @@ class Cluster(object):
                     if old_node is not node:
                         old_node.watch_log_for_alive(node, from_mark=mark)
 
-        if wait_for_binary_proto and self.version() >= '1.2':
-            for node, _, mark in started:
-                node.watch_log_for("Starting listening for CQL clients", process=p, verbose=verbose, from_mark=mark)
-            time.sleep(0.2)
+        if wait_for_binary_proto:
+            for node, p, mark in started:
+                node.wait_for_binary_interface(process=p, verbose=verbose, from_mark=mark)
 
         return started
 

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -376,6 +376,23 @@ def check_socket_available(itf):
         addr, port = itf
         raise UnavailableSocketError("Inet address %s:%s is not available: %s" % (addr, port, msg))
 
+
+def check_socket_listening(itf, timeout=60):
+    end = time.time() + timeout
+    while time.time() <= end:
+        try:
+            sock = socket.socket()
+            sock.connect(itf)
+            sock.close()
+            return True
+        except socket.error:
+            # Try again in another 200ms
+            time.sleep(.2)
+            continue
+
+    return False
+
+
 def interface_is_ipv6(itf):
     info = socket.getaddrinfo(itf[0], itf[1], socket.AF_UNSPEC, socket.SOCK_STREAM)
     if not info:

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -173,10 +173,7 @@ class DseNode(Node):
                 node.watch_log_for_alive(self, from_mark=mark)
 
         if wait_for_binary_proto:
-            self.watch_log_for("Starting listening for CQL clients")
-            # we're probably fine at that point but just wait some tiny bit more because
-            # the msg is logged just before starting the binary protocol server
-            time.sleep(0.2)
+            self.wait_for_binary_interface()
 
         if self.cluster.hasOpscenter():
             self._start_agent()


### PR DESCRIPTION
I was encountering a very rare and small timing window when running tests on a constrained VM (2 cores, 4GB ram) that had ongoing load where the binary interface wasn't available after ccm start even if --wait-for-binary-proto was used.

Replacing `time.sleep(0.2)` with a method that verifies the binary interface is listening by attempting to create a socket to it seems to resolve my issue (so far).   Will try for up to 10 seconds (more than reasonable if 'Starting listening for CQL clients' is spotted in the logs) and prints a warning and continues on if the interface is still not available.