### PR TITLE
Flush before kill on Windows. Add retry on deletion in cluster.remove()

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -561,6 +561,12 @@ class Node(object):
                 # We have recurring issues with nodes not stopping / releasing files in the CI
                 # environment so it makes more sense just to murder it hard since there's
                 # really little downside.
+
+                # We want the node to flush its data before shutdown as some tests rely on small writes being present.
+                # The default Periodic sync at 10 ms may not have flushed data yet, causing tests to fail.
+                if gently is True:
+                    self.flush()
+
                 os.system("taskkill /F /PID " + str(self.pid))
                 if self._find_pid_on_windows():
                     print_("WARN: Failed to terminate node: {0} with pid: {1}".format(self.name, self.pid))


### PR DESCRIPTION
Reference CASSANDRA-10075: The retry is an attempt to remedy an intermittent
failure in dtests where commitlogs cannot be deleted during cluster stop.
Flush before kill is an attempt to address a class of problems that has
shown up in various dtests while stabilizing Windows tests for 2.2.