### PR TITLE
fixes iteration over class names in set_log_level

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -320,6 +320,7 @@ class Cluster(object):
         return not_running
 
     def set_log_level(self, new_level, class_names=None):
+        class_names = class_names or []
         known_level = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'OFF']
         if new_level not in known_level:
             raise common.ArgumentError("Unknown log level %s (use one of %s)" % (new_level, " ".join(known_level)))


### PR DESCRIPTION
This didn't account for the code path where node.nodelist() was
populated and class_names was None, or otherwise not iterable. If the
class_names parameter has its default value of None, this line will set
it to an empty (iterable) list.