### PR TITLE
make flush failure silent on Windows node stop

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -564,8 +564,12 @@ class Node(object):
 
                 # We want the node to flush its data before shutdown as some tests rely on small writes being present.
                 # The default Periodic sync at 10 ms may not have flushed data yet, causing tests to fail.
+                # This is not a hard requirement, however, so we swallow any exceptions this may throw and kill anyway.
                 if gently is True:
-                    self.flush()
+                    try:
+                        self.flush()
+                    except:
+                        pass
 
                 os.system("taskkill /F /PID " + str(self.pid))
                 if self._find_pid_on_windows():


### PR DESCRIPTION
Caused 11 new failures since flush failure can rebound w/raised exception. If we fail to flush on shutdown it's not really an error, so changed to swallow exception during stop() on Windows.