### PR TITLE
Stress tool arguments not handled correctly

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -601,7 +601,7 @@ class ClusterStressCmd(Cmd):
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, load_cluster=True)
-        self.stress_options = parser.get_ignored() + args
+        self.stress_options = args + parser.get_ignored()
 
     def run(self):
         try:

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -599,7 +599,7 @@ class NodeStressCmd(Cmd):
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
-        self.stress_options = parser.get_ignored() + args[1:]
+        self.stress_options = args[1:] + parser.get_ignored()
 
     def run(self):
         try:

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -993,6 +993,9 @@ class Node(object):
         else:
             stress_options.append('-node')
             stress_options.append(self.address())
+        # specify used jmx port if not already set
+        if not [ opt for opt in stress_options if opt.startswith('jmx=') ]:
+            stress_options.extend(['-port', 'jmx=' + self.jmx_port])
         args = [stress] + stress_options
         try:
             subprocess.call(args, cwd=common.parse_path(stress), **kwargs)


### PR DESCRIPTION
1. Stress tool options need to be _appended_ to argument list. Example for using stress tool directly:
`ccm stress user profile=...yaml 'ops(simple1=1)' -port jmx=7100`
1. jmx port will now be set automatically for node specific runs

