### PR TITLE
Removed kwargs from node.run_sstablesplit

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -818,7 +818,7 @@ class Node(object):
             subprocess.call(args, env=env)
 
     def run_sstablesplit(self, datafiles=None,  size=None, keyspace=None, column_families=None,
-                         no_snapshot=False, debug=False, **kwargs):
+                         no_snapshot=False, debug=False):
         sstablesplit = self._find_cmd('sstablesplit')
         env = common.make_cassandra_env(self.get_install_cassandra_root(), self.get_node_cassandra_root())
         sstablefiles = self.__gather_sstables(datafiles, keyspace, column_families)
@@ -836,11 +836,11 @@ class Node(object):
                 cmd.append('--debug')
             cmd.append(f)
             p = subprocess.Popen(cmd, cwd=os.path.join(self.get_install_dir(), 'bin'),
-                                 env=env, stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-                                 **kwargs)
+                                 env=env, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
             (out, err) = p.communicate()
             rc = p.returncode
             results.append((out, err, rc))
+
 
         for sstablefile in sstablefiles:
             do_split(sstablefile)


### PR DESCRIPTION
[PR363](https://github.com/pcmanus/ccm/pull/363) caused a [regression](http://cassci.datastax.com/view/cassandra-3.0/job/cassandra-3.0_dtest/lastCompletedBuild/testReport/sstablesplit_test/TestSSTableSplit/single_file_split_test/history/) on dtest `single_file_split_test` because that test specifies the `stdout` paramter on `kwargs`, what causes a conflict when calling `subprocess.Popen`, with `stdout=subprocess.PIPE`.

The fix is to provide and `output_file` parameter instead, similar to what is done in other tool methods, such as `run_sstablemetadata` or `run_sstableexpiredblockers`, so we can make a conditional on that before calling `subprocess.Popen`.