### PR TITLE
Lastlog

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -40,6 +40,7 @@ def cluster_cmds():
         "verify",
         "invalidatecache",
         "checklogerror",
+        "showlastlog"
     ]
 
 def parse_populate_count(v):
@@ -837,3 +838,20 @@ class ClusterChecklogerrorCmd(Cmd):
             for mylist in errors:
                 for line in mylist:
                     print_(line)
+
+
+class ClusterShowlastlogCmd(Cmd):
+    def description(self):
+        return "Show the last.log for the most recent build through your $PAGER"
+
+    def get_parser(self):
+        usage = "usage: ccm showlastlog"
+        return self._get_default_parser(usage, self.description())
+
+    def validate(self, parser, options, args):
+        Cmd.validate(self, parser, options, args, load_cluster=True)
+
+    def run(self):
+        log = repository.lastlogfilename()
+        pager = os.environ.get('PAGER', common.platform_pager())
+        os.execvp(pager, (pager, log))

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -75,7 +75,7 @@ def clone_development(git_repo, version, verbose=False):
         git_repo_name = 'apache'
         git_branch = version.split(':', 1)[1]
     local_git_cache = os.path.join(__get_dir(), '_git_cache_' + git_repo_name)
-    logfile = os.path.join(__get_dir(), "last.log")
+    logfile = lastlogfilename()
     with open(logfile, 'w') as lf:
         try:
             #Checkout/fetch a local repository cache to reduce the number of
@@ -236,7 +236,7 @@ def download_version(version, url=None, verbose=False, binary=False):
 
 def compile_version(version, target_dir, verbose=False):
     # compiling cassandra and the stress tool
-    logfile = os.path.join(__get_dir(), "last.log")
+    logfile = lastlogfilename()
     if verbose:
         print_("Compiling Cassandra %s ..." % version)
     with open(logfile, 'w') as lf:
@@ -390,3 +390,6 @@ def __get_dir():
     if not os.path.exists(repo):
         os.mkdir(repo)
     return repo
+
+def lastlogfilename():
+    return os.path.join(__get_dir(), "last.log")

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -113,7 +113,11 @@ def clone_development(git_repo, version, verbose=False):
                     print_("Checking out requested branch (%s)" % git_branch)
                 out = subprocess.call(['git', 'checkout', git_branch], cwd=target_dir, stdout=lf, stderr=lf)
                 if int(out) != 0:
-                    raise CCMError("Could not check out git branch %s. Is this a valid branch name? (see last.log for details)" % git_branch)
+                    raise CCMError('Could not check out git branch {branch}. '
+                                   'Is this a valid branch name? (see {lastlog} or run '
+                                   '"ccm showlastlog" for details)'.format(
+                                       branch=git_branch, lastlog=logfile
+                                   ))
                 # now compile
                 compile_version(git_branch, target_dir, verbose)
             else: # branch is already checked out. See if it is behind and recompile if needed.
@@ -248,7 +252,8 @@ def compile_version(version, target_dir, verbose=False):
                 ret_val = subprocess.call([platform_binary('ant'),'jar'], cwd=target_dir, stdout=lf, stderr=lf)
                 attempt += 1
             if ret_val is not 0:
-                raise CCMError("Error compiling Cassandra. See %s for details" % logfile)
+                raise CCMError('Error compiling Cassandra. See {logfile} or run '
+                               '"ccm showlastlog" for details'.format(logfile=logfile))
         except OSError as e:
             raise CCMError("Error compiling Cassandra. Is ant installed? See %s for details" % logfile)
 


### PR DESCRIPTION
Adds a `showlastlog` cluster-level command to show `last.log`. I got annoyed when builds failed and I'd have to copy and paste the `last.log` path out of the error.

I also cleaned up `repository.py` a little to print the full `last.log` path. Now that I think about it, maybe those warnings should mention the new command.

In any event, I can iterate on this PR if you want the feature.