### PR TITLE
Added node.mark_log_for_errors() method

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -303,7 +303,16 @@ class Node(object):
         in the Cassandra log of this node
         """
         with open(self.logfilename()) as f:
+            if hasattr(self, 'error_mark'):
+                f.seek(self.error_mark)
             return _grep_log_for_errors(f.read())
+
+    def mark_log_for_errors(self):
+        """
+        Ignore errors behind this point when calling
+        node.grep_log_for_errors()
+        """
+        self.error_mark = self.mark_log()
 
     def mark_log(self):
         """


### PR DESCRIPTION
The `mark_log_for_errors()` creates a mark in the current position of the cassandra log of the given node, where all error logs before that mark will be ignored in the `grep_log_for_errors()` method.

The main use case for this right now, is to ignore all errors on cassandra 2.1 on Windows before upgrading to 2.2, in the context of `upgrade_internal_auth_test.py` (CASSANDRA-10037).