### PR TITLE
add versionfrombuild command

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -52,7 +52,8 @@ def node_cmds():
         "spark",
         "pause",
         "resume",
-        "jconsole"
+        "jconsole",
+        "versionfrombuild"
     ]
 
 
@@ -890,3 +891,20 @@ class NodeJconsoleCmd(Cmd):
         except OSError as e:
             print_("Could not start jconsole. Please make sure jconsole can be found in your $PATH.")
             exit(1)
+
+
+class NodeVersionfrombuildCmd(Cmd):
+
+    def description(self):
+        return "Print the node's version as grepped from build.xml. Can be used when the node isn't running."
+
+    def get_parser(self):
+        usage = "usage: ccm node_name versionfrombuild"
+        parser = self._get_default_parser(usage, self.description())
+        return parser
+
+    def validate(self, parser, options, args):
+        Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
+
+    def run(self):
+        print_(common.get_version_from_build(self.node.get_install_dir()))

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -907,4 +907,13 @@ class NodeVersionfrombuildCmd(Cmd):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
 
     def run(self):
-        print_(common.get_version_from_build(self.node.get_install_dir()))
+        version_from_nodetool = self.node.nodetool('version')[0].strip()
+        version_from_build = common.get_version_from_build(self.node.get_install_dir())
+
+        if version_from_nodetool and (version_from_nodetool != version_from_build):
+            print_('nodetool reports Cassandra version {ntv}; '
+                   'version from build.xml is {bv}'.format(ntv=version_from_nodetool,
+                                                           bv=version_from_build),
+                   file=sys.stderr)
+
+        print_(version_from_build)


### PR DESCRIPTION
This gives a CLI command for getting the version of a node from its build.xml file. The name of the command isn't final; it looks kind of gross int the top-level usage statement:

```
$ ccm
Missing arguments
Usage:
  ccm <cluster_cmd> [options]
  ccm <node_name> <node_cmd> [options]

Where <cluster_cmd> is one of
  create         Create a new cluster
  add            Add a new node to the current cluster
[...]
or <node_name> is the name of a node of the current cluster and <node_cmd> is one of
[...]
  pause          Send a SIGSTOP to this node
  resume         Send a SIGCONT to this node
  jconsole       Opens jconsole client and connect to running node
  versionfrombuild Print the node's version as grepped from build.xml. Can be used when the node isn't running.
```

See that last line -- the command name spills over. Don't know if the name of the command should change, if the logic for displaying commands should change, or if we care at all.

But, this could reduce duplication -- we do this in bash in the dtests on CassCI.