### PR TITLE
Modifications for DSE 4.8.0 support

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -527,7 +527,7 @@ def get_version_from_build(install_dir=None, node_path=None):
 def get_dse_version(install_dir):
     for root, dirs, files in os.walk(install_dir):
         for file in files:
-            match = re.search('^dse-([0-9.]+)(?:-SNAPSHOT)?\.jar', file)
+            match = re.search('^dse(?:-core)-([0-9.]+)(?:-SNAPSHOT)?\.jar', file)
             if match:
                 return match.group(1)
     return None

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -259,6 +259,8 @@ class DseNode(Node):
         for product in ['dse', 'cassandra', 'hadoop', 'sqoop', 'hive', 'tomcat', 'spark', 'shark', 'mahout', 'pig', 'solr']:
             src_conf = os.path.join(self.get_install_dir(), 'resources', product, 'conf')
             dst_conf = os.path.join(self.get_path(), 'resources', product, 'conf')
+            if not os.path.isdir(src_conf):
+                continue
             if os.path.isdir(dst_conf):
                 common.rmdirs(dst_conf)
             shutil.copytree(src_conf, dst_conf)


### PR DESCRIPTION
Added support for DSE 4.8.0.

* The dse jar filename changed from "dse-4.7.0.jar" to "dse-core-4.8.0.jar", modified get_dse_version to support new filename format.
* The dse 4.8.0 archive no longer contains ```resources/shark```, skip copying resources that don't exist.

