### PR TITLE
Use cassandra.logdir to specify log location

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -514,6 +514,7 @@ class Node(object):
 
         pidfile = os.path.join(self.get_path(), 'cassandra.pid')
         args = [launch_bin, '-p', pidfile, '-Dcassandra.join_ring=%s' % str(join_ring)]
+        args.append('-Dcassandra.logdir=%s' % os.path.join(self.get_path(), 'logs'))
         if replace_token is not None:
             args.append('-Dcassandra.replace_token=%s' % str(replace_token))
         if replace_address is not None:
@@ -1286,13 +1287,7 @@ class Node(object):
             common.replace_or_add_into_file_tail(conf_file, full_logger_pattern, full_logger_pattern + self.__classes_log_level[class_name])
 
     def __update_logback(self):
-        append_pattern = '<file>.*</file>'
         conf_file = os.path.join(self.get_conf_dir(), common.LOGBACK_CONF)
-        log_file = os.path.join(self.get_path(), 'logs', 'system.log')
-        common.replace_in_file(conf_file, append_pattern, '<file>' + log_file + '</file>')
-
-        append_pattern = '<fileNamePattern>.*</fileNamePattern>'
-        common.replace_in_file(conf_file, append_pattern, '<fileNamePattern>' + log_file + '.%i.zip</fileNamePattern>')
 
         self.__update_logback_loglevel(conf_file)
 


### PR DESCRIPTION
After CASSANDRA-10241, we have 2 log files by default.
Currently, ccm just replace contents of logback.xml to system.log, contents in system.log are now doubled.
This is causing dtest to fail when expecting only one log line is expected.

Proposed fix is to use `cassandra.logdir` env property.
Since that is available from 2.1, we can just remove replace code and add jvm option to it. (CASSANDRA-7136)