### PR TITLE
change git checkout command

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -114,9 +114,14 @@ def clone_development(git_repo, version, verbose=False):
                     subprocess.call(['git', 'clone', local_git_cache, target_dir], cwd=__get_dir(), stdout=lf, stderr=lf)
 
                 # now check out the right version
+                # we use checkout -B with --track so we can specify that we want to track a specific branch
+                # otherwise, you get errors on branch names that are also valid SHAs or SHA shortcuts, like 10360
+                # we use -B instead of -b so we reset branches that already exist and create a new one otherwise
                 if verbose:
                     print_("Checking out requested branch (%s)" % git_branch)
-                out = subprocess.call(['git', 'checkout', git_branch], cwd=target_dir, stdout=lf, stderr=lf)
+                out = subprocess.call(['git', 'checkout', '-B', git_branch,
+                                       '--track', 'origin/{git_branch}'.format(git_branch=git_branch)],
+                                      cwd=target_dir, stdout=lf, stderr=lf)
                 if int(out) != 0:
                     raise CCMError('Could not check out git branch {branch}. '
                                    'Is this a valid branch name? (see {lastlog} or run '


### PR DESCRIPTION
Fixes bug where you couldn't check things out if the branch name was a valid SHA shortcut.