### PR TITLE
added check to validate jdk >= 1.8 when C* >= 3.0 and fail with useful message on startup

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -264,6 +264,10 @@ class Cluster(object):
                 node.show(only_status=True)
 
     def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=[], profile_options=None):
+        if self.cassandra_version() >= '3.0' and common.get_jdk_version() < '1.8':
+            print_('Cassandra 3.0+ requires Java >= 1.8, found Java {}'.format(common.get_jdk_version()))
+            exit(1)
+
         if wait_other_notice:
             marks = [(node, node.mark_log()) for node in list(self.nodes.values())]
 

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -264,9 +264,7 @@ class Cluster(object):
                 node.show(only_status=True)
 
     def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=[], profile_options=None):
-        if self.cassandra_version() >= '3.0' and common.get_jdk_version() < '1.8':
-            print_('Cassandra 3.0+ requires Java >= 1.8, found Java {}'.format(common.get_jdk_version()))
-            exit(1)
+        common.assert_jdk_valid_for_cassandra_version(self.cassandra_version())
 
         if wait_other_notice:
             marks = [(node, node.mark_log()) for node in list(self.nodes.values())]

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -129,9 +129,7 @@ class ClusterCreateCmd(Cmd):
                 parser.print_help()
                 parser.error("%s is not a valid cassandra directory. You must define a cassandra dir or version." % options.install_dir)
 
-            if common.get_version_from_build(options.install_dir) >= '3.0' and common.get_jdk_version() < '1.8':
-                print_('Cassandra 3.0+ requires Java >= 1.8, found Java {}'.format(common.get_jdk_version()))
-                exit(1)
+            common.assert_jdk_valid_for_cassandra_version(common.get_version_from_build(options.install_dir))
 
     def run(self):
         try:

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -129,6 +129,10 @@ class ClusterCreateCmd(Cmd):
                 parser.print_help()
                 parser.error("%s is not a valid cassandra directory. You must define a cassandra dir or version." % options.install_dir)
 
+            if common.get_version_from_build(options.install_dir) >= '3.0' and common.get_jdk_version() < '1.8':
+                print_('Cassandra 3.0+ requires Java >= 1.8, found Java {}'.format(common.get_jdk_version()))
+                exit(1)
+
     def run(self):
         try:
             if self.options.dse or (not self.options.version and common.isDse(self.options.install_dir)):

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -569,3 +569,9 @@ def is_dse_cluster(path):
 
 def invalidate_cache():
     rmdirs(os.path.join(get_default_path(), 'repository'))
+
+
+def get_jdk_version():
+    version = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
+    ver_pattern = '\"(\d+\.\d+).*\"'
+    return re.search(ver_pattern, version).groups()[0]

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -575,3 +575,9 @@ def get_jdk_version():
     version = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
     ver_pattern = '\"(\d+\.\d+).*\"'
     return re.search(ver_pattern, version).groups()[0]
+
+
+def assert_jdk_valid_for_cassandra_version(cassandra_version):
+    if cassandra_version >= '3.0' and get_jdk_version() < '1.8':
+        print_('ERROR: Cassandra 3.0+ requires Java >= 1.8, found Java {}'.format(get_jdk_version()))
+        exit(1)

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -15,6 +15,7 @@ from distutils.version import LooseVersion
 
 from six import print_
 
+from common import get_jdk_version, get_version_from_build
 from ccmlib.common import (ArgumentError, CCMError, get_default_path,
                            platform_binary, rmdirs, validate_install_dir)
 from six.moves import urllib
@@ -262,6 +263,10 @@ def download_version(version, url=None, verbose=False, binary=False):
 
 
 def compile_version(version, target_dir, verbose=False):
+    if get_version_from_build(target_dir) >= '3.0' and get_jdk_version() < '1.8':
+        print_('ERROR: Cassandra 3.0+ requires Java >= 1.8, found Java {}'.format(get_jdk_version()))
+        exit(1)
+
     # compiling cassandra and the stress tool
     logfile = lastlogfilename()
     if verbose:

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -15,7 +15,7 @@ from distutils.version import LooseVersion
 
 from six import print_
 
-from common import get_jdk_version, get_version_from_build
+from common import assert_jdk_valid_for_cassandra_version, get_version_from_build
 from ccmlib.common import (ArgumentError, CCMError, get_default_path,
                            platform_binary, rmdirs, validate_install_dir)
 from six.moves import urllib
@@ -219,6 +219,8 @@ def download_version(version, url=None, verbose=False, binary=False):
 
     if binary == True, download precompiled tarball, otherwise build from source tarball.
     """
+    assert_jdk_valid_for_cassandra_version(version)
+
     if binary:
         u = "%s/%s/apache-cassandra-%s-bin.tar.gz" % (ARCHIVE, version.split('-')[0], version) if url is None else url
     else:
@@ -263,9 +265,7 @@ def download_version(version, url=None, verbose=False, binary=False):
 
 
 def compile_version(version, target_dir, verbose=False):
-    if get_version_from_build(target_dir) >= '3.0' and get_jdk_version() < '1.8':
-        print_('ERROR: Cassandra 3.0+ requires Java >= 1.8, found Java {}'.format(get_jdk_version()))
-        exit(1)
+    assert_jdk_valid_for_cassandra_version(get_version_from_build(target_dir))
 
     # compiling cassandra and the stress tool
     logfile = lastlogfilename()


### PR DESCRIPTION
Added for #347.  Had to add to more places that seem right, but wanted to protect against: binary, src, git, github and install-dir options.