### PR TITLE
Add hints_dir to conf based on node, not cluster version

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1262,7 +1262,7 @@ class Node(object):
         data['data_file_directories'] = [os.path.join(self.get_path(), 'data')]
         data['commitlog_directory'] = os.path.join(self.get_path(), 'commitlogs')
         data['saved_caches_directory'] = os.path.join(self.get_path(), 'saved_caches')
-        if self.cluster.version() > '3.0' and 'hints_directory' in yaml_text:
+        if self.get_cassandra_version() > '3.0' and 'hints_directory' in yaml_text:
             data['hints_directory'] = os.path.join(self.get_path(), 'data', 'hints')
 
         if self.cluster.partitioner:


### PR DESCRIPTION
During rolling upgrades, the cluster version remains on the old
version as individual nodes are updated. When a node is upgraded
to 3.0+, this leads to the hints_directory setting not being added
to its config. In turn, this means that the hints dir defaults to
a location under CASSANDRA_HOME which is shared by all nodes in
he cluster. From that, all manner of hijinks ensue with nodes
wiping out each other's hints files, causing seemingly random
exceptions and other fun stuff.