### PR TITLE
PEP8 Fixes

### DIFF
--- a/ccm
+++ b/ccm
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys
+import os
+import sys
 
 from six import print_
 
 from ccmlib import common
 from ccmlib.cmds import command, cluster_cmds, node_cmds
+
 
 def get_command(kind, cmd):
     cmd_name = kind.lower().capitalize() + cmd.lower().capitalize() + "Cmd"
@@ -16,6 +18,7 @@ def get_command(kind, cmd):
     if not issubclass(klass, command.Cmd):
         return None
     return klass()
+
 
 def print_global_usage():
     print_("Usage:")

--- a/ccm
+++ b/ccm
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import os
 import sys
 
 from six import print_

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -6,12 +6,12 @@ import shutil
 import subprocess
 import time
 
-from six import iteritems, print_
-
 import yaml
+from six import iteritems, print_
+from six.moves import xrange
+
 from ccmlib import common, repository
 from ccmlib.node import Node, NodeError
-from six.moves import xrange
 
 
 class Cluster(object):

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -1,6 +1,7 @@
 import os
 
 import yaml
+
 from ccmlib import common, repository
 from ccmlib.cluster import Cluster
 from ccmlib.dse_cluster import DseCluster

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -1,6 +1,6 @@
 import os
-import sys
 import subprocess
+import sys
 
 from six import print_
 

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -718,7 +718,7 @@ class NodeSetworkloadCmd(Cmd):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
         self.workload = args[1]
         workloads = ['cassandra', 'solr', 'hadoop', 'spark', 'cfs']
-        if not self.workload in workloads:
+        if self.workload not in workloads:
             print_(self.workload, ' is not a valid workload')
             exit(1)
 

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -1,6 +1,6 @@
 import os
-import sys
 import subprocess
+import sys
 
 from six import print_
 

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -13,9 +13,8 @@ import subprocess
 import sys
 import time
 
-from six import print_
-
 import yaml
+from six import print_
 
 BIN_DIR = "bin"
 CASSANDRA_CONF_DIR = "conf"

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -157,7 +157,7 @@ def replaces_or_add_into_file_tail(file, replacement_list):
                 if "</configuration>" not in line:
                     f_tmp.write(line)
             # In case, entry is not found, and need to be added
-            if is_line_found == False:
+            if not is_line_found:
                 f_tmp.write('\n' + replace + "\n")
             # We are moving the closing tag to the end of the file.
             # Previously, we were having an issue where new lines we wrote
@@ -248,7 +248,7 @@ def check_win_requirements():
 
         # Confirm matching architectures
         # 32-bit python distributions will launch 32-bit cmd environments, losing PowerShell execution privileges on a 64-bit system
-        if sys.maxsize <= 2**32 and platform.machine().endswith('64'):
+        if sys.maxsize <= 2 ** 32 and platform.machine().endswith('64'):
             sys.exit("ERROR!  64-bit os and 32-bit python distribution found.  ccm requires matching architectures.")
 
 

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -261,6 +261,7 @@ def is_ps_unrestricted():
     else:
         try:
             p = subprocess.Popen(['powershell', 'Get-ExecutionPolicy'], stdout=subprocess.PIPE)
+        # pylint: disable=E0602
         except WindowsError:
             print_("ERROR: Could not find powershell. Is it in your path?")
         if "Unrestricted" in p.communicate()[0]:

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -9,9 +9,9 @@ import stat
 import subprocess
 import time
 
+import yaml
 from six import print_
 
-import yaml
 from ccmlib import common
 from ccmlib.node import Node, NodeError
 

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -17,6 +17,7 @@ from ccmlib.node import Node, NodeError
 
 
 class DseNode(Node):
+
     """
     Provides interactions to a DSE node.
     """
@@ -102,7 +103,7 @@ class DseNode(Node):
 
         if profile_options is not None:
             config = common.get_config()
-            if not 'yourkit_agent' in config:
+            if 'yourkit_agent' not in config:
                 raise NodeError("Cannot enable profile. You need to set 'yourkit_agent' to the path of your agent in a {0}/config".format(common.get_default_path_display_name()))
             cmd = '-agentpath:%s' % config['yourkit_agent']
             if 'options' in profile_options:

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -67,6 +67,7 @@ _sstable_regexp = re.compile('((?P<keyspace>[^\s-]+)-(?P<cf>[^\s-]+)-)?(?P<tmp>t
 
 
 class Node(object):
+
     """
     Provides interactions to a Cassandra node.
     """
@@ -933,7 +934,7 @@ class Node(object):
         sstablefiles = self.__gather_sstables(datafiles, keyspace, column_families)
 
         for sstable in sstablefiles:
-            if set_repaired == True:
+            if set_repaired:
                 cmd = [sstablerepairedset, "--really-set", "--is-repaired", sstable]
             else:
                 cmd = [sstablerepairedset, "--really-set", "--is-unrepaired", sstable]
@@ -946,7 +947,7 @@ class Node(object):
 
         cmd = [sstablelevelreset, "--really-reset", keyspace, cf]
 
-        if output == True:
+        if output:
             p = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, env=env)
             (stdout, stderr) = p.communicate()
             rc = p.returncode
@@ -959,12 +960,12 @@ class Node(object):
         sstableofflinerelevel = common.join_bin(cdir, os.path.join('tools', 'bin'), 'sstableofflinerelevel')
         env = common.make_cassandra_env(cdir, self.get_path())
 
-        if dry_run == True:
+        if dry_run:
             cmd = [sstableofflinerelevel, "--dry-run", keyspace, cf]
         else:
             cmd = [sstableofflinerelevel, keyspace, cf]
 
-        if output == True:
+        if output:
             p = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, env=env)
             (stdout, stderr) = p.communicate()
             rc = p.returncode
@@ -981,7 +982,7 @@ class Node(object):
         if options is not None:
             cmd[1:1] = options
 
-        if output == True:
+        if output:
             p = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, env=env)
             (stdout, stderr) = p.communicate()
             rc = p.returncode

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -15,13 +15,13 @@ import time
 import warnings
 from datetime import datetime
 
-from six import iteritems, print_, string_types
-
 import yaml
+from six import iteritems, print_, string_types
+from six.moves import xrange
+
 from ccmlib import common
 from ccmlib.cli_session import CliSession
 from ccmlib.repository import setup
-from six.moves import xrange
 
 
 class Status():

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -158,7 +158,7 @@ def clone_development(git_repo, version, verbose=False):
                     # we use -B instead of -b so we reset branches that already exist and create a new one otherwise
                     out = subprocess.call(['git', 'checkout', '-B', git_branch,
                                            '--track', 'origin/{git_branch}'.format(git_branch=git_branch)],
-                                           cwd=target_dir, stdout=lf, stderr=lf)
+                                          cwd=target_dir, stdout=lf, stderr=lf)
                 else:
                     out = subprocess.call(['git', 'checkout', git_branch], cwd=target_dir, stdout=lf, stderr=lf)
                 if int(out) != 0:

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -14,11 +14,11 @@ import time
 from distutils.version import LooseVersion
 
 from six import print_
+from six.moves import urllib
 
 from ccmlib.common import (ArgumentError, CCMError, get_default_path,
                            platform_binary, rmdirs, validate_install_dir,
                            assert_jdk_valid_for_cassandra_version, get_version_from_build)
-from six.moves import urllib
 
 DSE_ARCHIVE = "http://downloads.datastax.com/enterprise/dse-%s-bin.tar.gz"
 OPSC_ARCHIVE = "http://downloads.datastax.com/community/opscenter-%s.tar.gz"

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -146,7 +146,7 @@ def clone_development(git_repo, version, verbose=False):
                     branches = [b.strip() for b in branch_listing.replace('remotes/origin/', '').split()]
                     is_branch = git_branch in branches
                 except subprocess.CalledProcessError as cpe:
-                        print_("Error Running Branch Filter: {}\nAssumming request is not for a branch".format(cpe.output))
+                    print_("Error Running Branch Filter: {}\nAssumming request is not for a branch".format(cpe.output))
 
                 # now check out the right version
                 if verbose:

--- a/tests/ccmtest.py
+++ b/tests/ccmtest.py
@@ -1,5 +1,5 @@
-from unittest import TestCase
 import os
+from unittest import TestCase
 
 
 class Tester(TestCase):

--- a/tests/ccmtest.py
+++ b/tests/ccmtest.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 import os
 
+
 class Tester(TestCase):
 
     def __init__(self, *argv, **kwargs):

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -2,7 +2,9 @@ from . import TEST_DIR
 from . import ccmtest
 from ccmlib.cluster import Cluster
 from ccmlib import common
-import subprocess, os, yaml
+import subprocess
+import os
+import yaml
 from six import print_
 
 CLUSTER_PATH = TEST_DIR
@@ -12,6 +14,7 @@ class TestCCMCmd(ccmtest.Tester):
 
     def __init__(self, *args, **kwargs):
         ccmtest.Tester.__init__(self, *args, **kwargs)
+
 
 class TestCCMCreate(TestCCMCmd):
 
@@ -49,7 +52,7 @@ class TestCCMCreate(TestCCMCmd):
         self.validate_output(self.create_cmd(args, version=None))
 
     def cluster_create_populate_test(self):
-        args = ['-n','3']
+        args = ['-n', '3']
         self.validate_output(self.create_cmd(args))
 
     def cluster_create_no_switch_test(self):

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -1,11 +1,12 @@
-from . import TEST_DIR
-from . import ccmtest
-from ccmlib.cluster import Cluster
-from ccmlib import common
-import subprocess
 import os
+import subprocess
+
 import yaml
 from six import print_
+
+from ccmlib import common
+from . import TEST_DIR
+from . import ccmtest
 
 CLUSTER_PATH = TEST_DIR
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,6 +2,7 @@ from . import ccmtest
 from ccmlib import common
 import yaml
 
+
 class TestCommon(ccmtest.Tester):
 
     def test_normalize_interface(self):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,5 @@
-from . import ccmtest
 from ccmlib import common
-import yaml
+from . import ccmtest
 
 
 class TestCommon(ccmtest.Tester):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -21,4 +21,4 @@ class TestCommon(ccmtest.Tester):
         self.assertEqual(normalized, ('fd6d:404d:54cb:0:0:0:0:1', 9042))
 
 if __name__ == '__main__':
-        unittest.main()
+    unittest.main()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,5 @@
+import unittest
+
 from ccmlib import common
 from . import ccmtest
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,7 +1,7 @@
-from . import TEST_DIR
-from . import ccmtest
 from ccmlib.cluster import Cluster
 from ccmlib.node import Node
+from . import TEST_DIR
+from . import ccmtest
 
 CLUSTER_PATH = TEST_DIR
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -5,6 +5,7 @@ from ccmlib.node import Node
 
 CLUSTER_PATH = TEST_DIR
 
+
 class TestCCMIssues(ccmtest.Tester):
 
     def issue_150_test(self):
@@ -15,7 +16,7 @@ class TestCCMIssues(ccmtest.Tester):
         dcs.append('dc2')
 
         node4 = Node('node4', self.cluster, True, ('127.0.0.4', 9160), ('127.0.0.4', 7000),
-            '7400', '2000', None)
+                     '7400', '2000', None)
         self.cluster.add(node4, False, 'dc2')
         node4.start()
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -11,6 +11,7 @@ from six import StringIO
 
 CLUSTER_PATH = TEST_DIR
 
+
 class TestCCMLib(ccmtest.Tester):
 
     def simple_test(self, version='2.0.9'):
@@ -73,7 +74,6 @@ class TestCCMLib(ccmtest.Tester):
         self.cluster.flush()
         self.cluster.stop()
 
-
     def test2(self):
         self.cluster = Cluster(CLUSTER_PATH, "test2", cassandra_version='2.0.3')
         self.cluster.populate(2)
@@ -95,7 +95,6 @@ class TestCCMLib(ccmtest.Tester):
         self.cluster.drain()
         self.cluster.stop()
 
-
     def test3(self):
         self.cluster = Cluster(CLUSTER_PATH, "test3", cassandra_version='2.0.3')
         self.cluster.populate(2)
@@ -107,6 +106,7 @@ class TestCCMLib(ccmtest.Tester):
 
 
 class TestRunCqlsh(ccmtest.Tester):
+
     def setUp(self):
         '''Create a cluster for cqlsh tests. Assumes that ccmtest.Tester's
         teardown() method will safely stop and remove self.cluster.'''
@@ -175,6 +175,7 @@ class TestRunCqlsh(ccmtest.Tester):
 
 
 class TestNodeLoad(ccmtest.Tester):
+
     def test_rejects_multiple_load_lines(self):
         info = 'Load : 699 KB\nLoad : 35 GB'
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
I was taking a look at ccm's code with a checking tool I wrote (similar to pyflakes) that helped me prepare some PEP8, pylint and other fixes. If you guys think it's interesting, I could also send a PR to perform an automated CI job on each PR through Travis CI (this way, the amount of lint/pep8 errors that get into CCM master will reduce substantially).