### PR TITLE
Use quiet flag for windows

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -527,6 +527,8 @@ class Node(object):
         if use_jna is False:
             args.append('-Dcassandra.boot_without_jna=true')
         env['JVM_EXTRA_OPTS'] = env.get('JVM_EXTRA_OPTS', "") + " " + " ".join(jvm_args)
+        if common.is_win():
+            args.append('-q')
 
         # In case we are restarting a node
         # we risk reading the old cassandra.pid file


### PR DESCRIPTION
[Cassandra 3.0 on Windows uses `-NoNewWindow` argument by default](https://github.com/apache/cassandra/commit/f8783b7bb1bd16d29565c3be86480a7188e91ee0#diff-67909d13f7884e965e96d1df987e43ebR263). When starting ccm from another process, it causes `ccm start` to never return as cassandra subprocess is running on the same window.

Using cassandra.ps1 -q flag solves the issue.

cc @josh-mckenzie