### PR TITLE
add watch_log_for_listening method

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -440,6 +440,15 @@ class Node(object):
         tofind = ["%s.* now UP" % node.address() for node in tofind]
         self.watch_log_for(tofind, from_mark=from_mark, timeout=timeout, filename=filename)
 
+    def watch_log_for_listening(self, from_mark=None, timeout=120, filename='system.log'):
+        """
+        Watch the log of this node until it is listening for CQL clients.
+        """
+        self.watch_log_for("Starting listening for CQL clients",
+                           from_mark=from_mark,
+                           timeout=timeout,
+                           filename=filename)
+
     def wait_for_binary_interface(self, **kwargs):
         """
         Waits for the Binary CQL interface to be listening.  If > 1.2 will check


### PR DESCRIPTION
Adds a method, like watch_log_for_alive, that waits for the node it's called on to be listening for CQL clients. `wait_for_binary_interface` isn't what I want because it also times out checking for a listening socket, which is not what I want to do.

(Incidentally, I don't understand the design of `wait_for_binary_interface`. If the socket isn't listening, why print a warning rather than raise an exception?)