### PR TITLE
DSE Version Detection broken < DSE 4.8.0

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -529,7 +529,7 @@ def get_version_from_build(install_dir=None, node_path=None):
 def get_dse_version(install_dir):
     for root, dirs, files in os.walk(install_dir):
         for file in files:
-            match = re.search('^dse(?:-core)-([0-9.]+)(?:-SNAPSHOT)?\.jar', file)
+            match = re.search('^dse(?:-core)?-([0-9.]+)(?:-SNAPSHOT)?\.jar', file)
             if match:
                 return match.group(1)
     return None


### PR DESCRIPTION
Fix for https://github.com/pcmanus/ccm/pull/376/files#diff-e19f0f0ec871623be418f8c4e97f9f46L530

The updated regex in that commit only supports DSE >= 4.8.0 (where the jar file name changed to dse-core-X.Y.Z.jar), and fails for earlier DSE versions (where the jar file name was dse-X.Y.Z.jar).  