### PR TITLE
add jstack method to Node

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1638,6 +1638,14 @@ class Node(object):
             else:
                 os.kill(self.pid, signal.SIGCONT)
 
+    def jstack(self, opts=None):
+        opts = [] if opts is None else opts
+        jstack_location = os.path.abspath(os.path.join(os.environ['JAVA_HOME'],
+                                                       'bin',
+                                                       'jstack'))
+        jstack_cmd = [jstack_location, '-J-d64'] + opts + [str(self.pid)]
+        return subprocess.Popen(jstack_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
 
 def _get_load_from_info_output(info):
     load_lines = [s for s in info.split('\n')


### PR DESCRIPTION
I've chosen here to give the `jstack` method an optional `opts` parameter that takes a list of options, like you'd see in `subprocess.Popen`. The method returns directly the result of `subprocess.Popen()` so callers can do what they want with it, getting the output of `std{out,err}` or checking the return value.

The APIs for the `Node` methods that shell out to other processes are inconsistent (and some of them Are Bad), so I don't feel too bad about giving this an API that I like, but isn't consistent with the others. If you think I should feel bad, let me know.

I've smoke-tested this with this script:

https://gist.github.com/8e2552a5692730c65957