### PR TITLE
ccmlib: Avoid passing mutable default argument to jvm_args

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -263,7 +263,10 @@ class Cluster(object):
             else:
                 node.show(only_status=True)
 
-    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=[], profile_options=None, quiet_start=False):
+    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=None, profile_options=None, quiet_start=False):
+        if jvm_args is None:
+            jvm_args = []
+
         common.assert_jdk_valid_for_cassandra_version(self.cassandra_version())
 
         if wait_other_notice:

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -32,7 +32,9 @@ class DseCluster(Cluster):
     def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None):
         return DseNode(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface)
 
-    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=[], profile_options=None, quiet_start=False):
+    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=None, profile_options=None, quiet_start=False):
+        if jvm_args is None:
+            jvm_args = []
         started = super(DseCluster, self).start(no_wait, verbose, wait_for_binary_proto, wait_other_notice, jvm_args, profile_options)
         self.start_opscenter()
         return started

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -66,7 +66,7 @@ class DseNode(Node):
               wait_other_notice=False,
               replace_token=None,
               replace_address=None,
-              jvm_args=[],
+              jvm_args=None,
               wait_for_binary_proto=False,
               profile_options=None,
               use_jna=False,
@@ -81,6 +81,8 @@ class DseNode(Node):
           - replace_token: start the node with the -Dcassandra.replace_token option.
           - replace_address: start the node with the -Dcassandra.replace_address option.
         """
+        if jvm_args is None:
+            jvm_args = []
 
         if self.is_running():
             raise NodeError("%s is already running" % self.name)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -464,7 +464,7 @@ class Node(object):
               wait_other_notice=False,
               replace_token=None,
               replace_address=None,
-              jvm_args=[],
+              jvm_args=None,
               wait_for_binary_proto=False,
               profile_options=None,
               use_jna=False,
@@ -479,6 +479,8 @@ class Node(object):
           - replace_token: start the node with the -Dcassandra.replace_token option.
           - replace_address: start the node with the -Dcassandra.replace_address option.
         """
+        if jvm_args is None:
+            jvm_args = []
         # Validate Windows env
         if common.is_win() and not common.is_ps_unrestricted() and self.cluster.version() >= '2.1':
             raise NodeError("PS Execution Policy must be unrestricted when running C* 2.1+")


### PR DESCRIPTION
Change jvm_args default value to None, then in the method
body check if it's None, then assign it to an empty list.
This avoids surprises if multiple calls to the methods
are made [1].

[1] http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments
