### PR TITLE
Adding command line arg for credentials file.

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -78,6 +78,8 @@ class ClusterCreateCmd(Cmd):
                           help="The username to use to download DSE with", default=None)
         parser.add_option("--dse-password", type="string", dest="dse_password",
                           help="The password to use to download DSE with", default=None)
+        parser.add_option("--dse-credentials", type="string", dest="dse_credentials_file",
+                          help="A file containing the dse_username, and dse_password.", default=None)
         parser.add_option("--install-dir", type="string", dest="install_dir",
                           help="Path to the cassandra or dse directory to use [default %default]", default="./")
         parser.add_option('-n', '--nodes', type="string", dest="nodes",
@@ -138,7 +140,7 @@ class ClusterCreateCmd(Cmd):
     def run(self):
         try:
             if self.options.dse or (not self.options.version and common.isDse(self.options.install_dir)):
-                cluster = DseCluster(self.path, self.name, install_dir=self.options.install_dir, version=self.options.version, dse_username=self.options.dse_username, dse_password=self.options.dse_password, opscenter=self.options.opscenter, verbose=True)
+                cluster = DseCluster(self.path, self.name, install_dir=self.options.install_dir, version=self.options.version, dse_username=self.options.dse_username, dse_password=self.options.dse_password, dse_credentials_file=self.options.dse_credentials_file, opscenter=self.options.opscenter, verbose=True)
             else:
                 cluster = Cluster(self.path, self.name, install_dir=self.options.install_dir, version=self.options.version, verbose=True)
         except OSError as e:

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import signal
 import subprocess
+import ConfigParser
 
 from six import iteritems
 
@@ -13,9 +14,12 @@ from ccmlib.dse_node import DseNode
 
 class DseCluster(Cluster):
 
-    def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, dse_username=None, dse_password=None, opscenter=None, verbose=False):
-        self.dse_username = dse_username
-        self.dse_password = dse_password
+    def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, dse_username=None, dse_password=None, dse_credentials_file=None, opscenter=None, verbose=False):
+        if dse_credentials_file:
+            self.load_credentials_from_file(dse_credentials_file)
+        else:
+            self.dse_username = dse_username
+            self.dse_password = dse_password
         self.opscenter = opscenter
         super(DseCluster, self).__init__(path, name, partitioner, install_dir, create_directory, version, verbose)
 
@@ -25,6 +29,12 @@ class DseCluster(Cluster):
             target_dir = os.path.join(self.get_path(), 'opscenter')
             shutil.copytree(odir, target_dir)
         return repository.setup_dse(version, self.dse_username, self.dse_password, verbose)
+
+    def load_credentials_from_file(self, dse_credentials_file):
+        parser = ConfigParser.ConfigParser()
+        parser.read(dse_credentials_file)
+        self.dse_username = parser.get('dse_credentials','dse_username')
+        self.dse_password = parser.get('dse_credentials','dse_password')
 
     def hasOpscenter(self):
         return os.path.exists(os.path.join(self.get_path(), 'opscenter'))


### PR DESCRIPTION
This change would allow for users to provide a credentials file that contains dse_username and dse_password to use for credentials instead of passing them in explicitly.

I think this change would be useful for anyone who is trying to share common credentials, or keep credentials out of logs. 

The format of the credentials file would be as follows.

[dse_credentials]
dse_username = username
dse_password = password