### PR TITLE
Add flag to enable starting cassandra as root for CASSANDRA-8142

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -263,7 +263,7 @@ class Cluster(object):
             else:
                 node.show(only_status=True)
 
-    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=None, profile_options=None, quiet_start=False):
+    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=None, profile_options=None, quiet_start=False, allow_root=False):
         if jvm_args is None:
             jvm_args = []
 
@@ -279,7 +279,7 @@ class Cluster(object):
                 if os.path.exists(node.logfilename()):
                     mark = node.mark_log()
 
-                p = node.start(update_pid=False, jvm_args=jvm_args, profile_options=profile_options, verbose=verbose, quiet_start=quiet_start)
+                p = node.start(update_pid=False, jvm_args=jvm_args, profile_options=profile_options, verbose=verbose, quiet_start=quiet_start, allow_root=allow_root)
                 started.append((node, p, mark))
 
         if no_wait and not verbose:

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -185,7 +185,7 @@ class ClusterCreateCmd(Cmd):
                         profile_options = {}
                         if self.options.profile_options:
                             profile_options['options'] = self.options.profile_options
-                    if cluster.start(verbose=self.options.debug_log, wait_for_binary_proto=self.options.binary_protocol, jvm_args=self.options.jvm_args, profile_options=profile_options) is None:
+                    if cluster.start(verbose=self.options.debug_log, wait_for_binary_proto=self.options.binary_protocol, jvm_args=self.options.jvm_args, profile_options=profile_options, allow_root=self.options.allow_root) is None:
                         details = ""
                         if not self.options.debug_log:
                             details = " (you can use --debug-log for more information)"
@@ -527,6 +527,7 @@ class ClusterStartCmd(Cmd):
         parser.add_option('--profile-opts', type="string", action="store", dest="profile_options",
                           help="Yourkit options when profiling", default=None)
         parser.add_option('--quiet-windows', action="store_true", dest="quiet_start", help="Pass -q on Windows 2.2.4+ and 3.0+ startup. Ignored on linux.", default=False)
+        parser.add_option('--root', action="store_true", dest="allow_root", help="Allow CCM to start cassandra as root", default=False)
         return parser
 
     def validate(self, parser, options, args):
@@ -550,7 +551,8 @@ class ClusterStartCmd(Cmd):
                                   verbose=self.options.verbose,
                                   jvm_args=self.options.jvm_args,
                                   profile_options=profile_options,
-                                  quiet_start=self.options.quiet_start) is None:
+                                  quiet_start=self.options.quiet_start,
+                                  allow_root=self.options.allow_root) is None:
                 details = ""
                 if not self.options.verbose:
                     details = " (you can use --verbose for more information)"

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -184,6 +184,7 @@ class NodeStartCmd(Cmd):
         parser.add_option('--jvm_arg', action="append", dest="jvm_args",
                           help="Specify a JVM argument", default=[])
         parser.add_option('--quiet-windows', action="store_true", dest="quiet_start", help="Pass -q on Windows 2.2.4+ and 3.0+ startup. Ignored on linux.", default=False)
+        parser.add_option('--root', action="store_true", dest="allow_root", help="Allow CCM to start cassandra as root", default=False)
         return parser
 
     def validate(self, parser, options, args):
@@ -198,7 +199,8 @@ class NodeStartCmd(Cmd):
                             verbose=self.options.verbose,
                             replace_address=self.options.replace_address,
                             jvm_args=self.options.jvm_args,
-                            quiet_start=self.options.quiet_start)
+                            quiet_start=self.options.quiet_start,
+                            allow_root=self.options.allow_root)
         except NodeError as e:
             print_(str(e), file=sys.stderr)
             print_("Standard error output is:", file=sys.stderr)

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -42,10 +42,10 @@ class DseCluster(Cluster):
     def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None):
         return DseNode(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface)
 
-    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=None, profile_options=None, quiet_start=False):
+    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=False, jvm_args=None, profile_options=None, quiet_start=False, allow_root=False):
         if jvm_args is None:
             jvm_args = []
-        started = super(DseCluster, self).start(no_wait, verbose, wait_for_binary_proto, wait_other_notice, jvm_args, profile_options)
+        started = super(DseCluster, self).start(no_wait, verbose, wait_for_binary_proto, wait_other_notice, jvm_args, profile_options, quiet_start=quiet_start, allow_root=allow_root)
         self.start_opscenter()
         return started
 

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -70,7 +70,8 @@ class DseNode(Node):
               wait_for_binary_proto=False,
               profile_options=None,
               use_jna=False,
-              quiet_start=False):
+              quiet_start=False,
+              allow_root=False):
         """
         Start the node. Options includes:
           - join_ring: if false, start the node with -Dcassandra.join_ring=False
@@ -142,6 +143,8 @@ class DseNode(Node):
             args.append('-Dcassandra.replace_address=%s' % str(replace_address))
         if use_jna is False:
             args.append('-Dcassandra.boot_without_jna=true')
+        if allow_root:
+            args.append('-R')
         args = args + jvm_args
 
         process = None

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -468,7 +468,8 @@ class Node(object):
               wait_for_binary_proto=False,
               profile_options=None,
               use_jna=False,
-              quiet_start=False):
+              quiet_start=False,
+              allow_root=False):
         """
         Start the node. Options includes:
           - join_ring: if false, start the node with -Dcassandra.join_ring=False
@@ -538,6 +539,8 @@ class Node(object):
             args.append('-Dcassandra.replace_address=%s' % str(replace_address))
         if use_jna is False:
             args.append('-Dcassandra.boot_without_jna=true')
+        if allow_root:
+            args.append('-R')
         env['JVM_EXTRA_OPTS'] = env.get('JVM_EXTRA_OPTS', "") + " " + " ".join(jvm_args)
 
         # In case we are restarting a node


### PR DESCRIPTION
CASSANDRA-8142 adds -R to allow bin/cassandra to run as root - this patch adds --root to the ccm node commands to add -R, allowing that same functionality. This allows scripts that run as root for whatever reason to continue working post-8142
