### PR TITLE
Use ~/.ccm/.dse.ini as dse credentials file if it exists by default.

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -79,7 +79,7 @@ class ClusterCreateCmd(Cmd):
         parser.add_option("--dse-password", type="string", dest="dse_password",
                           help="The password to use to download DSE with", default=None)
         parser.add_option("--dse-credentials", type="string", dest="dse_credentials_file",
-                          help="A file containing the dse_username, and dse_password.", default=None)
+                          help="An ini-style config file containing the dse_username and dse_password under a dse_credentials section. [default to {0}/.dse.ini if it exists]".format(common.get_default_path_display_name()), default=None)
         parser.add_option("--install-dir", type="string", dest="install_dir",
                           help="Path to the cassandra or dse directory to use [default %default]", default="./")
         parser.add_option('-n', '--nodes', type="string", dest="nodes",

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -79,7 +79,7 @@ class ClusterCreateCmd(Cmd):
         parser.add_option("--dse-password", type="string", dest="dse_password",
                           help="The password to use to download DSE with", default=None)
         parser.add_option("--dse-credentials", type="string", dest="dse_credentials_file",
-                          help="An ini-style config file containing the dse_username and dse_password under a dse_credentials section. [default to {0}/.dse.ini if it exists]".format(common.get_default_path_display_name()), default=None)
+                          help="An ini-style config file containing the dse_username and dse_password under a dse_credentials section. [default to {}/.dse.ini if it exists]".format(common.get_default_path_display_name()), default=None)
         parser.add_option("--install-dir", type="string", dest="install_dir",
                           help="Path to the cassandra or dse directory to use [default %default]", default="./")
         parser.add_option('-n', '--nodes', type="string", dest="nodes",

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -18,10 +18,12 @@ from ccmlib.dse_node import DseNode
 class DseCluster(Cluster):
 
     def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, dse_username=None, dse_password=None, dse_credentials_file=None, opscenter=None, verbose=False):
-        if dse_credentials_file:
-            self.load_credentials_from_file(dse_credentials_file)
-        else:
+        self.dse_username = None
+        self.dse_password = None
+        self.load_credentials_from_file(dse_credentials_file)
+        if dse_username is not None:
             self.dse_username = dse_username
+        if dse_password is not None:
             self.dse_password = dse_password
         self.opscenter = opscenter
         super(DseCluster, self).__init__(path, name, partitioner, install_dir, create_directory, version, verbose)
@@ -34,6 +36,12 @@ class DseCluster(Cluster):
         return repository.setup_dse(version, self.dse_username, self.dse_password, verbose)
 
     def load_credentials_from_file(self, dse_credentials_file):
+        # Use .dse.ini if it exists in the default .ccm directory. 
+        if dse_credentials_file is None:
+            creds_file = os.path.join(common.get_default_path(), '.dse.ini')
+            if os.path.isfile(creds_file):
+                dse_credentials_file = creds_file
+        
         parser = ConfigParser.ConfigParser()
         parser.read(dse_credentials_file)
         self.dse_username = parser.get('dse_credentials','dse_username')


### PR DESCRIPTION
I really like the recent addition of the '--dse-credentials' config parameter for loading credentials from a config file.   For convenience I think it would be nice if there were a default credentials file that, if exists, will be loaded to grab the dse credentials.   This would remove the need to pass the path of the credentials file each time you create a cluster.

The existing behavior:

* If user passes in --dse-credentials, grab dse_username and dse_password from the passed in config file.
* Else grab from --dse-username and/or --dse-password

The new behavior:

* If user doesn't pass in --dse-credentials and .dse.ini exists, set dse_username and dse_password based on it's contents.
* Else If user passes in --dse-credentials, grab dse_username and dse_password from the passed in config file.
* If --dse-username and/or --dse-password were passed in explicitly, override the dse_username and dse_password values.