### PR TITLE
Only log dse credentials are missing when attempting to download.

### DIFF
--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -27,10 +27,6 @@ class DseCluster(Cluster):
         if dse_password is not None:
             self.dse_password = dse_password
 
-        if self.dse_username is None:
-            print_("Warning: No dse username detected, specify one using --dse-username or passing in a credentials file using --dse-credentials.", file=sys.stderr)
-        if self.dse_password is None:
-            print_("Warning: No dse password detected, specify one using --dse-password or passing in a credentials file using --dse-credentials.", file=sys.stderr)
         self.opscenter = opscenter
         super(DseCluster, self).__init__(path, name, partitioner, install_dir, create_directory, version, verbose)
 

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -197,6 +197,10 @@ def download_dse_version(version, username, password, verbose=False):
     url = DSE_ARCHIVE % version
     _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
     try:
+        if username is None:
+            print_("Warning: No dse username detected, specify one using --dse-username or passing in a credentials file using --dse-credentials.", file=sys.stderr)
+        if password is None:
+            print_("Warning: No dse password detected, specify one using --dse-password or passing in a credentials file using --dse-credentials.", file=sys.stderr)
         __download(url, target, username=username, password=password, show_progress=verbose)
         if verbose:
             print_("Extracting %s as version %s ..." % (target, version))


### PR DESCRIPTION
It looks like I introduced an annoying regression in #426.   The log messages I added for informing a user that they were not providing DSE credentials were evaluated when running *any* command against a DSE cluster.   This should really only be logged before you go to download a DSE version.   This makes that adjustment so the log message only appears when it is relevant.   

Props to @kishkaru for noticing this :).