### PR TITLE
Avoid potential deadlock when running cqlsh

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -769,15 +769,15 @@ class Node(object):
             else:
                 os.execve(cqlsh, [common.platform_binary('cqlsh')] + args, env)
         else:
-            p = subprocess.Popen([cqlsh] + args, env=env, stdin=subprocess.PIPE, stderr=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
+            p = subprocess.Popen([cqlsh] + args, env=env, stdin=subprocess.PIPE, stderr=subprocess.PIPE,
+                                 stdout=subprocess.PIPE, universal_newlines=True)
+            cmd_str = ''
             for cmd in cmds.split(';'):
                 cmd = cmd.strip()
                 if cmd:
-                    p.stdin.write(cmd + ';\n')
-            p.stdin.write("quit;\n")
-            p.wait()
-
-            output = (p.stdout.read(), p.stderr.read())
+                    cmd_str += (cmd + ';\n')
+            cmd_str += "quit;\n"
+            output = p.communicate(input=cmd_str)
 
             for err in output[1].split('\n'):
                 print_("(EE) ", err, end='')


### PR DESCRIPTION
As described in the [documentation] (https://docs.python.org/2.7/library/subprocess.html#subprocess.Popen.wait), using `p.wait()` may result in a deadlock. This seems to happen quite regularly on Windows, although I did see it once on Linux too. The solution is quite simple, just use `p.communicate()` instead. This should be safe provided the input and output can be buffered in memory.