### PR TITLE
Only use dictionary update if the new value is a dictionary

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1308,7 +1308,7 @@ class Node(object):
                     pass
             else:
                 try:
-                    if isinstance(data[name], dict):
+                    if isinstance(data[name], dict) and isinstance(full_options[name], dict):
                         for option in full_options[name]:
                             data[name][option] = full_options[name][option]
                     else:


### PR DESCRIPTION
We are missing the case where you want to replace a value
in cassandra.yaml that is normally a dict, with a single key.
For example, with just "None".

Fixes #434.