### PR TITLE
Automatically set migration_task_wait_in_seconds to double node count

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -174,6 +174,7 @@ class Cluster(object):
     def populate(self, nodes, debug=False, tokens=None, use_vnodes=False, ipprefix='127.0.0.', ipformat=None, install_byteman=False):
         node_count = nodes
         dcs = []
+
         self.use_vnodes = use_vnodes
         if isinstance(nodes, list):
             self.set_configuration_options(values={'endpoint_snitch': 'org.apache.cassandra.locator.PropertyFileSnitch'})
@@ -305,7 +306,9 @@ class Cluster(object):
             else:
                 node.show(only_status=True)
 
-    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=True, jvm_args=None, profile_options=None, quiet_start=False, allow_root=False):
+    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False,
+              wait_other_notice=True, jvm_args=None, profile_options=None,
+              quiet_start=False, allow_root=False):
         if jvm_args is None:
             jvm_args = []
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -477,7 +477,8 @@ class Node(object):
               profile_options=None,
               use_jna=False,
               quiet_start=False,
-              allow_root=False):
+              allow_root=False,
+              set_migration_task=True):
         """
         Start the node. Options includes:
           - join_ring: if false, start the node with -Dcassandra.join_ring=False
@@ -490,6 +491,10 @@ class Node(object):
         """
         if jvm_args is None:
             jvm_args = []
+
+        if set_migration_task and self.cluster.cassandra_version() >= '3.0.1':
+            jvm_args += ['-Dcassandra.migration_task_wait_in_seconds={}'.format(len(self.cluster.nodes) * 2)]
+
         # Validate Windows env
         if common.is_win() and not common.is_ps_unrestricted() and self.cluster.version() >= '2.1':
             raise NodeError("PS Execution Policy must be unrestricted when running C* 2.1+")


### PR DESCRIPTION
@mambocab to review. The relevant test now passes locally for me. I'll try it out on cassci