### PR TITLE
Improve handling when not all loopback addresses are available

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -395,7 +395,7 @@ def validate_install_dir(install_dir):
         raise ArgumentError('%s does not appear to be a cassandra or dse installation directory' % install_dir)
 
 
-def check_socket_available(itf):
+def check_socket_available(itf, return_on_error=False):
     info = socket.getaddrinfo(itf[0], itf[1], socket.AF_UNSPEC, socket.SOCK_STREAM)
     if not info:
         raise UnavailableSocketError("Failed to get address info for [%s]:%s" % itf)
@@ -407,8 +407,11 @@ def check_socket_available(itf):
     try:
         s.bind(sockaddr)
         s.close()
+        return True
     except socket.error as msg:
         s.close()
+        if return_on_error:
+            return False
         addr, port = itf
         raise UnavailableSocketError("Inet address %s:%s is not available: %s" % (addr, port, msg))
 


### PR DESCRIPTION
On Mac the user needs to make sure the loopback addresses (127.0.0.2, 127.0.0.3, etc.)
are created. Currently if they aren't created, ccm fails when creating the cluster,
but leaves it in a partial state (usually just the first node is running).

This change does a pre-flight check to make sure all loopbacks are available, print
a better warning, and exit before starting any nodes.