### PR TITLE
Restore previous ability of cluster.start() to start partially downed clusters

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -316,13 +316,14 @@ class Cluster(object):
         common.assert_jdk_valid_for_cassandra_version(self.cassandra_version())
 
         # check whether all loopback aliases are available before starting any nodes
-        for node in self.nodes.values():
-            for itf in node.network_interfaces.values():
-                if itf is not None:
-                    if not common.check_socket_available(itf, return_on_error=True):
-                        addr, port = itf
-                        print_("Inet address %s:%s is not available; a cluster may already be running or you may need to add the loopback alias" % (addr, port))
-                        sys.exit(1)
+        for node in list(self.nodes.values()):
+            if not node.is_running():
+                for itf in node.network_interfaces.values():
+                    if itf is not None:
+                        if not common.check_socket_available(itf, return_on_error=True):
+                            addr, port = itf
+                            print_("Inet address %s:%s is not available; a cluster may already be running or you may need to add the loopback alias" % (addr, port))
+                            sys.exit(1)
 
         started = []
         for node in list(self.nodes.values()):


### PR DESCRIPTION

This PR only checks interface availability for nodes that aren't started when doing a cluster.start(). This keeps the positive effects of the previous PR (no partial states if another cluster is left running or interfaces not available) while restoring idempotent starts and the ability to use start for only partially downed clusters.