### PR TITLE
Allow nesting > 2 for updateconf/updatedseconf, persist and read dse_config_options

### DIFF
--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -35,6 +35,8 @@ class ClusterFactory():
                 cluster.partitioner = data['partitioner']
             if 'config_options' in data:
                 cluster._config_options = data['config_options']
+            if 'dse_config_options' in data:
+                cluster._dse_config_options = data['dse_config_options']
             if 'log_level' in data:
                 cluster.__log_level = data['log_level']
             if 'use_vnodes' in data:

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -487,14 +487,15 @@ def parse_settings(args, literal_yaml=False):
                 # Where we are currently at in the dict.
                 tree_pos = settings
                 # Iterate over each split and build structure as needed.
-                for pos in xrange(split_length):
+                for pos in range(split_length):
                     split = splitted[pos]
                     if pos == split_length - 1:
                         # If at the last split, set value.
                         tree_pos[split] = val
                     else:
                         # If not at last split, create a new dict at the current
-                        # position for this split.
+                        # position for this split if it doesn't already exist
+                        # and update the current position.
                         if split not in tree_pos:
                             tree_pos[split] = {}
                         tree_pos = tree_pos[split]
@@ -613,7 +614,7 @@ def merge_configuration(original, changes, delete_empty=True):
         new = copy.deepcopy(original)
         for k, v in changes.iteritems():
             # If the new value is None or an empty string, delete it
-            # if its in the original data.
+            # if it's in the original data.
             if delete_empty and k in new and \
                     (v is None or (isinstance(v, str) and len(v) == 0)):
                 del new[k]

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -409,17 +409,14 @@ class DseNode(Node):
 
         data['system_key_directory'] = os.path.join(self.get_path(), 'keys')
 
-        full_options = dict(list(self.cluster._dse_config_options.items()) + list(self._dse_config_options.items()))
-        for name in full_options:
-            value = full_options[name]
-            if isinstance(value, str) and (value is None or len(value) == 0):
-                try:
-                    del data[name]
-                except KeyError:
-                    # it is fine to remove a key not there
-                    pass
-            else:
-                data[name] = full_options[name]
+        # Get a map of combined cluster and node configuration with the node
+        # configuration taking precedence.
+        full_options = common.merge_configuration(
+            self.cluster._dse_config_options,
+            self._dse_config_options, delete_empty=False)
+
+        # Merge options with original yaml data.
+        data = common.merge_configuration(data, full_options)
 
         with open(conf_file, 'w') as f:
             yaml.safe_dump(data, f, default_flow_style=False)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -141,6 +141,8 @@ class Node(object):
                 node.__install_dir = data['install_dir']
             if 'config_options' in data:
                 node.__config_options = data['config_options']
+            if 'dse_config_options' in data:
+                node._dse_config_options = data['dse_config_options']
             if 'data_center' in data:
                 node.data_center = data['data_center']
             if 'workloads' in data:
@@ -1302,6 +1304,7 @@ class Node(object):
             'interfaces': self.network_interfaces,
             'jmx_port': self.jmx_port,
             'config_options': self.__config_options,
+            'dse_config_options': self._dse_config_options
         }
         if self.pid:
             values['pid'] = self.pid


### PR DESCRIPTION
This does a bunch of little things which may not be useful in the general case, but is good to have:

* Previously with updateconf/updatedseconf, someone could specify a nested structure, i.e.:

    ```bash
    ccm updateconf "client_encryption_options.enabled: true"
    ```

    This would update cassandra.yaml with:

    ```bash
    client_encryption_options:
      enabled: true
    ```

    In the general case this is more than enough, but there were a few problems:

    1. It would update in place for updateconf (i.e. if there are other options under client_encryption_options, those would remain unchanged), but not with updatedseconf (it'd blow away all children except the newly added element), reconciled that logic into `common#merge_configuration`.
    2. You couldn't nest > 2 deep, i.e. "spark_application_info_options.driver.sink:true" would not update:

        ```yaml
        spark_application_info:
          driver:
            sink: true
        ```

        Instead it would do:

        ```yaml
        spark_application_info.driver.sink: true
        ```

    Commit 37afe6a reconciles this.

* Configuration for updatedseconf at both the cluster and node level was not being read in when loading the cluster/nodes.   It was also not being persisted at the node level (my mistake since I added that capability).  Commit 201694f reconciles this.

    An example to experiment with this:

    Update and cluster level with a delete, and then the node level undoing the delete with nested values:

    ```bash
    ccm updatedseconf "spark_application_info_options.driver.sink:true" "spark_application_info_options.driver.jvmSource:"
    ccm node1 updatedseconf "spark_application_info_options.driver.jvmSource:true"
    ```

    sink should be true in dse.yaml for all nodes, jvmSource should be present in node1, but not the rest of the nodes.