### PR TITLE
Fixing ipv6 for C* with versions > 3.2

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -22,6 +22,7 @@ DSE_CASSANDRA_CONF_DIR = "resources/cassandra/conf"
 OPSCENTER_CONF_DIR = "conf"
 
 CASSANDRA_CONF = "cassandra.yaml"
+JVM_OPTS = "jvm.options"
 LOG4J_CONF = "log4j-server.properties"
 LOG4J_TOOL_CONF = "log4j-tools.properties"
 LOGBACK_CONF = "logback.xml"

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1444,11 +1444,13 @@ class Node(object):
         # The cassandra-env.ps1 file has been introduced in 2.1
         if common.is_win() and self.get_base_cassandra_version() >= 2.1:
             conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_WIN_ENV)
+            jvm_file = os.path.join(self.get_conf_dir(), common.JVM_OPTS)
             jmx_port_pattern = '^\s+\$JMX_PORT='
             jmx_port_setting = '    $JMX_PORT="' + self.jmx_port + '"'
             remote_debug_options = '    $env:JVM_OPTS="$env:JVM_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=' + str(self.remote_debug_port) + '"'
         else:
             conf_file = os.path.join(self.get_conf_dir(), common.CASSANDRA_ENV)
+            jvm_file = os.path.join(self.get_conf_dir(), common.JVM_OPTS)
             jmx_port_pattern = 'JMX_PORT='
             jmx_port_setting = 'JMX_PORT="' + self.jmx_port + '"'
             remote_debug_options = 'JVM_OPTS="$JVM_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=' + str(self.remote_debug_port) + '"'
@@ -1500,15 +1502,22 @@ class Node(object):
 
         for itf in list(self.network_interfaces.values()):
             if itf is not None and common.interface_is_ipv6(itf):
-                if common.is_win():
-                    common.replace_in_file(conf_file,
-                                           '-Djava.net.preferIPv4Stack=true',
-                                           '\t$env:JVM_OPTS="$env:JVM_OPTS -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"')
+                if self.get_cassandra_version() < '3.2':
+                    if common.is_win():
+                        common.replace_in_file(conf_file,
+                                               '-Djava.net.preferIPv4Stack=true',
+                                               '\t$env:JVM_OPTS="$env:JVM_OPTS -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"')
+                    else:
+                        common.replace_in_file(conf_file,
+                                               '-Djava.net.preferIPv4Stack=true',
+                                               'JVM_OPTS="$JVM_OPTS -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"')
+                    break
                 else:
-                    common.replace_in_file(conf_file,
-                                           '-Djava.net.preferIPv4Stack=true',
-                                           'JVM_OPTS="$JVM_OPTS -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"')
-                break
+                    common.replace_in_file(jvm_file,'-Djava.net.preferIPv4Stack=true','')
+                    break
+
+
+
 
     def __update_status(self):
         if self.pid is None:


### PR DESCRIPTION
This allows me to spin up C* cluster newer the 3.2 with IPV6.

I tested these changes against 3.4, and 3.0.3  It seems wot work with both paths. 
Take a look and let me know. I'm not sure the "-Djava.net.preferIPv6Addresses=true" was needed as it worked fine without it so I left it absent, and simply removed '-Djava.net.preferIPv4Stack=true' from the jvm.options file
