### PR TITLE
Revert "Assert that wait_other_notice and join_ring are not used together"

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -512,8 +512,6 @@ class Node(object):
                 common.check_socket_available(itf)
 
         if wait_other_notice:
-            if not join_ring:
-                raise NodeError("Other nodes will never see this node %s as UP when join_ring=False" % self.name)
             marks = [(node, node.mark_log()) for node in list(self.cluster.nodes.values()) if node.is_live()]
 
         self.mark = self.mark_log()


### PR DESCRIPTION
Reverts pcmanus/ccm#479