### PR TITLE
add node.Node.envfilename method

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -306,6 +306,12 @@ class Node(object):
     def debuglogfilename(self):
         return os.path.join(self.get_path(), 'logs', 'debug.log')
 
+    def envfilename(self):
+        return os.path.join(
+            self.get_conf_dir(),
+            common.CASSANDRA_WIN_ENV if common.is_win() else common.CASSANDRA_ENV
+        )
+
     def grep_log(self, expr, filename='system.log'):
         """
         Returns a list of lines matching the regular expression in parameter


### PR DESCRIPTION
[This code](https://github.com/beobal/cassandra-dtest/blob/10091/jmxutils.py#L55) from [@beobal's recent PR](https://github.com/riptano/cassandra-dtest/pull/887) is necessary but silly. This PR adds a method that makes it unnecessary.

(Also, if it weren't inconsistent with existing APIs, I'd make this a `@property`. Is that a refactoring we'd consider in the long term? If so, maybe we could make this one from the get-go.)