### PR TITLE
Timeout param node start

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -238,7 +238,7 @@ def make_dse_env(install_dir, node_path, node_ip):
     env['SPARK_MASTER_LOG_DIR'] = os.path.join(node_path, 'logs', 'spark', 'master')
     env['DSE_LOG_ROOT'] = os.path.join(node_path, 'logs', 'dse')
     env['CASSANDRA_LOG_DIR'] = os.path.join(node_path, 'logs')
-    env['SPARK_LOCAL_IP'] = ''+node_ip
+    env['SPARK_LOCAL_IP'] = '' + node_ip
     return env
 
 

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -627,3 +627,12 @@ def merge_configuration(original, changes, delete_empty=True):
                         new_value = merge_configuration(new[k], v, delete_empty)
                 new[k] = new_value
     return new
+
+
+def is_intlike(obj):
+    try:
+        int(obj)
+        return True
+    except TypeError:
+        return False
+    raise RuntimeError('Reached end of {}; should not be possible'.format(is_intlike.__name__))

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -492,8 +492,8 @@ class Node(object):
           - join_ring: if false, start the node with -Dcassandra.join_ring=False
           - no_wait: by default, this method returns when the node is started and listening to clients.
             If no_wait=True, the method returns sooner.
-          - wait_other_notice: if True, this method returns only when all other live node of the cluster
-            have marked this node UP.
+          - wait_other_notice: if truthy, this method returns only when all other live node of the cluster
+            have marked this node UP. if an integer, sets the timeout for how long to wait
           - replace_token: start the node with the -Dcassandra.replace_token option.
           - replace_address: start the node with the -Dcassandra.replace_address option.
         """
@@ -600,7 +600,12 @@ class Node(object):
             if not self.is_running():
                 raise NodeError("Error starting node %s" % self.name, process)
 
-        if wait_other_notice:
+        # If wait_other_notice is a bool, we don't want to treat it as a
+        # timeout. Other intlike types, though, we want to use.
+        if common.is_intlike(wait_other_notice) and not isinstance(wait_other_notice, bool):
+            for node, mark in marks:
+                node.watch_log_for_alive(self, from_mark=mark, timeout=wait_other_notice)
+        elif wait_other_notice:
             for node, mark in marks:
                 node.watch_log_for_alive(self, from_mark=mark)
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -609,7 +609,11 @@ class Node(object):
             for node, mark in marks:
                 node.watch_log_for_alive(self, from_mark=mark)
 
-        if wait_for_binary_proto:
+        # If wait_for_binary_proto is a bool, we don't want to treat it as a
+        # timeout. Other intlike types, though, we want to use.
+        if common.is_intlike(wait_for_binary_proto) and not isinstance(wait_for_binary_proto, bool):
+            self.wait_for_binary_interface(from_mark=self.mark, timeout=wait_for_binary_proto)
+        elif wait_for_binary_proto:
             self.wait_for_binary_interface(from_mark=self.mark)
 
         return process


### PR DESCRIPTION
This makes the `wait_other_notice` and `wait_for_binary_proto` params able to specify timeouts if they are integers.