### PR TITLE
Fixed memory label to align to CASSANDRA-9692 

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1787,9 +1787,15 @@ def _get_load_from_info_output(info):
         raise RuntimeError(msg)
     load_line = load_lines[0].split()
 
-    unit_multipliers = {'KB': 1,
+    # Don't have access to C* version here, so we need to support both prefix styles
+    # See CASSANDRA-9692 on Apache JIRA
+    unit_multipliers = {'KiB': 1,
+                        'KB': 1,
+                        'MiB': 1024,
                         'MB': 1024,
+                        'GiB': 1024 * 1024,
                         'GB': 1024 * 1024,
+                        'TiB': 1024 * 1024 * 1024,
                         'TB': 1024 * 1024 * 1024}
     load_num, load_units = load_line[2], load_line[3]
 


### PR DESCRIPTION
[CASSANDRA-9692](https://issues.apache.org/jira/browse/CASSANDRA-9692) unifies/improves logging/output of data sizes and rates throughout C*.

As part of this normalization, it changes the output of nodetool info to use the correct SI prefixes. The only dependency on this I could locate for CCM is in its parsing of the nodetool info output. This parsing happens in a function without the C* version available, so we can't do a version check to determine correct units. This PR proposes the easy route of supporting both unit types; another option is to refactor the tests/call sites to pass in a C* version, so that we can decide based on version.

(Please note that I'm reviewer for the above ticket, not assignee. PRing this since it is a new contributor and managing a C* ticket/CCM PR/dtest PR isn't the easiest thing).