### PR TITLE
Use sstabledump for json command if available

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -451,7 +451,7 @@ class NodeVerifyCmd(Cmd):
 class NodeJsonCmd(Cmd):
 
     def description(self):
-        return "Call sstable2json on the sstables of this node"
+        return "Call sstable2json/sstabledump on the sstables of this node"
 
     def get_parser(self):
         usage = "usage: ccm node_name json [options] [file]"
@@ -481,10 +481,16 @@ class NodeJsonCmd(Cmd):
     def run(self):
         try:
             with open(self.outfile, 'w') as f:
-                self.node.run_sstable2json(keyspace=self.keyspace,
-                                           out_file=f,
-                                           column_families=self.column_families,
-                                           enumerate_keys=self.options.enumerate_keys)
+                if self.node.has_cmd('sstable2json'):
+                    self.node.run_sstable2json(keyspace=self.keyspace,
+                                               out_file=f,
+                                               column_families=self.column_families,
+                                               enumerate_keys=self.options.enumerate_keys)
+                elif self.node.has_cmd('sstabledump'):
+                    self.node.run_sstabledump(keyspace=self.keyspace,
+                                               output_file=f,
+                                               column_families=self.column_families,
+                                               enumerate_keys=self.options.enumerate_keys)
         except common.ArgumentError as e:
             print_(e, file=sys.stderr)
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1091,11 +1091,18 @@ class Node(object):
         else:
             fcmd = common.join_bin(cdir, 'bin', cmd)
         try:
-            os.chmod(fcmd, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+            if os.path.exists(fcmd):
+                os.chmod(fcmd, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
         except:
             print_("WARN: Couldn't change permissions to use {0}.".format(cmd))
             print_("WARN: If it didn't work, you will have to do so manually.")
         return fcmd
+
+    def has_cmd(self, cmd):
+        """
+        Indicates if specified command can be found under cassandra root
+        """
+        return os.path.exists(self._find_cmd(cmd))
 
     def list_keyspaces(self):
         keyspaces = os.listdir(os.path.join(self.get_path(), 'data0'))


### PR DESCRIPTION
`ccm json` is currently broken for Cassandra 3.x, but we can just use the `sstabledump` tool in this case.