### PR TITLE
Use dict.items instead of iteritems

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -613,7 +613,7 @@ def merge_configuration(original, changes, delete_empty=True):
     else:
         # Copy original so we do not mutate it.
         new = copy.deepcopy(original)
-        for k, v in changes.iteritems():
+        for k, v in changes.items():
             # If the new value is None or an empty string, delete it
             # if it's in the original data.
             if delete_empty and k in new and \


### PR DESCRIPTION
Python3 compatibility problem. this dict will never be large
enough that we need the iterator in py2

Closes #492 

@mambocab and @tolbertam to review, please. (It was Andy/My code that caused the bug)