### PR TITLE
Enable seed addresses to be explicitly set

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -291,7 +291,7 @@ class Cluster(object):
         return os.path.join(self.__path, self.name)
 
     def get_seeds(self):
-        return [s.network_interfaces['storage'][0] for s in self.seeds]
+        return [s.network_interfaces['storage'][0] if isinstance(s, Node) else s for s in self.seeds]
 
     def show(self, verbose):
         msg = "Cluster: '%s'" % self.name
@@ -519,7 +519,7 @@ class Cluster(object):
 
     def _update_config(self):
         node_list = [node.name for node in list(self.nodes.values())]
-        seed_list = [node.name for node in self.seeds]
+        seed_list = self.get_seeds()
         filename = os.path.join(self.__path, self.name, 'cluster.conf')
         with open(filename, 'w') as f:
             yaml.safe_dump({

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -48,7 +48,7 @@ class ClusterFactory():
 
         for node_name in node_list:
             cluster.nodes[node_name] = Node.load(cluster_path, node_name, cluster)
-        for seed_name in seed_list:
-            cluster.seeds.append(cluster.nodes[seed_name])
+        for seed in seed_list:
+            cluster.seeds.append(seed)
 
         return cluster


### PR DESCRIPTION
So we can specify that a node's broadcast_address can be used in the seed list. See CASSANDRA-10134 (specifically https://issues.apache.org/jira/browse/CASSANDRA-10134?focusedCommentId=15243094&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15243094)