### PR TITLE
Use correct port for sstableloader

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -742,7 +742,7 @@ class Node(object):
     def bulkload(self, options):
         loader_bin = common.join_bin(self.get_path(), 'bin', 'sstableloader')
         env = self.get_env()
-        host, port = self.network_interfaces['thrift']
+        host, port = self.network_interfaces['binary']
         args = ['-d', host, '-p', str(port)]
         os.execve(loader_bin, [common.platform_binary('sstableloader')] + args + options, env)
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -742,7 +742,8 @@ class Node(object):
     def bulkload(self, options):
         loader_bin = common.join_bin(self.get_path(), 'bin', 'sstableloader')
         env = self.get_env()
-        host, port = self.network_interfaces['binary']
+        # CASSANDRA-8358 switched from thrift to binary port
+        host, port = self.network_interfaces['thrift'] if self.get_cassandra_version() < '2.2' else self.network_interfaces['binary']
         args = ['-d', host, '-p', str(port)]
         os.execve(loader_bin, [common.platform_binary('sstableloader')] + args + options, env)
 


### PR DESCRIPTION
Looks like **ccm** is connecting to the **thrift** port by default instead of the binary port **9042**.

````
$ ccm node1 bulkload /tmp/dataset1/keyspace1/standard1/ -v
All host(s) tried for query failed (tried: /127.0.0.1:9160 (com.datastax.driver.core.exceptions.TransportException: [/127.0.0.1] Cannot connect))
com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed (tried: /127.0.0.1:9160 (com.datastax.driver.core.exceptions.TransportException: [/127.0.0.1] Cannot connect))
    at com.datastax.driver.core.ControlConnection.reconnectInternal(ControlConnection.java:231)
    at com.datastax.driver.core.ControlConnection.connect(ControlConnection.java:77)
    at com.datastax.driver.core.Cluster$Manager.init(Cluster.java:1414)
    at com.datastax.driver.core.Cluster.init(Cluster.java:162)
    at com.datastax.driver.core.Cluster.connectAsync(Cluster.java:333)
    at com.datastax.driver.core.Cluster.connectAsync(Cluster.java:308)
    at com.datastax.driver.core.Cluster.connect(Cluster.java:250)
    at org.apache.cassandra.utils.NativeSSTableLoaderClient.init(NativeSSTableLoaderClient.java:70)
    at org.apache.cassandra.io.sstable.SSTableLoader.stream(SSTableLoader.java:159)
    at org.apache.cassandra.tools.BulkLoader.main(BulkLoader.java:104)
```

Also `-p port` can't be used because it complains about **too many arguments**:
````
$ ccm node1 bulkload -p 9042 /tmp/dataset1/keyspace1/standard1/

Too many arguments
```