### PR TITLE
separated batch_commitlog from set_configuration_options

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -444,25 +444,20 @@ class Cluster(object):
             raise common.ArgumentError("No live node")
         livenodes[0].run_cli(cmds, show_output, cli_options)
 
-    def set_configuration_options(self, values=None, batch_commitlog=None):
+    def set_configuration_options(self, values=None):
         if values is not None:
             for k, v in iteritems(values):
                 self._config_options[k] = v
-        if batch_commitlog is not None:
-            if batch_commitlog:
-                self._config_options["commitlog_sync"] = "batch"
-                self._config_options["commitlog_sync_batch_window_in_ms"] = 5
-                self._config_options["commitlog_sync_period_in_ms"] = None
-            else:
-                self._config_options["commitlog_sync"] = "periodic"
-                self._config_options["commitlog_sync_period_in_ms"] = 10000
-                self._config_options["commitlog_sync_batch_window_in_ms"] = None
 
         self._update_config()
         for node in list(self.nodes.values()):
             node.import_config_files()
         self.__update_topology_files()
         return self
+
+    def set_batch_commitlog(self, enabled):
+        for node in list(self.nodes.values()):
+            node.set_batch_commitlog(enabled=enabled)
 
     def set_dse_configuration_options(self, values=None):
         raise common.ArgumentError('Cannot set DSE configuration options on a Cassandra cluster')

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -694,7 +694,9 @@ class ClusterUpdateconfCmd(Cmd):
         parser.add_option('--no-hh', '--no-hinted-handoff', action="store_false",
                           dest="hinted_handoff", default=True, help="Disable hinted handoff")
         parser.add_option('--batch-cl', '--batch-commit-log', action="store_true",
-                          dest="cl_batch", default=False, help="Set commit log to batch mode")
+                          dest="cl_batch", default=None, help="Set commit log to batch mode")
+        parser.add_option('--periodic-cl', '--periodic-commit-log', action="store_true",
+                          dest="cl_periodic", default=None, help="Set commit log to periodic mode")
         parser.add_option('--rt', '--rpc-timeout', action="store", type='int',
                           dest="rpc_timeout", help="Set rpc timeout")
         parser.add_option('-y', '--yaml', action="store_true", dest="literal_yaml", default=False, help="If enabled, treat argument as yaml, not kv pairs. Option syntax looks like ccm updateconf -y 'a: [b: [c,d]]'")
@@ -704,6 +706,10 @@ class ClusterUpdateconfCmd(Cmd):
         Cmd.validate(self, parser, options, args, load_cluster=True)
         try:
             self.setting = common.parse_settings(args, literal_yaml=self.options.literal_yaml)
+            if self.options.cl_batch and self.options.cl_periodic:
+                print_("Can't set commitlog to be both batch and periodic.{}".format(os.linesep))
+                parser.print_help()
+                exit(1)
         except common.ArgumentError as e:
             print_(str(e), file=sys.stderr)
             exit(1)
@@ -721,7 +727,11 @@ class ClusterUpdateconfCmd(Cmd):
                 self.setting['truncate_request_timeout_in_ms'] = self.options.rpc_timeout
                 self.setting['request_timeout_in_ms'] = self.options.rpc_timeout
 
-        self.cluster.set_configuration_options(values=self.setting, batch_commitlog=self.options.cl_batch)
+        self.cluster.set_configuration_options(values=self.setting)
+        if self.options.cl_batch:
+            self.cluster.set_batch_commitlog(True)
+        if self.options.cl_periodic:
+            self.cluster.set_batch_commitlog(False)
 
 
 class ClusterUpdatedseconfCmd(Cmd):

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -588,7 +588,9 @@ class NodeUpdateconfCmd(Cmd):
         parser.add_option('--no-hh', '--no-hinted-handoff', action="store_false",
                           dest="hinted_handoff", default=True, help="Disable hinted handoff")
         parser.add_option('--batch-cl', '--batch-commit-log', action="store_true",
-                          dest="cl_batch", default=False, help="Set commit log to batch mode")
+                          dest="cl_batch", default=None, help="Set commit log to batch mode")
+        parser.add_option('--periodic-cl', '--periodic-commit-log', action="store_true",
+                          dest="cl_periodic", default=None, help="Set commit log to periodic mode")
         parser.add_option('--rt', '--rpc-timeout', action="store", type='int',
                           dest="rpc_timeout", help="Set rpc timeout")
         parser.add_option('-y', '--yaml', action="store_true", dest="literal_yaml",
@@ -600,6 +602,10 @@ class NodeUpdateconfCmd(Cmd):
         args = args[1:]
         try:
             self.setting = common.parse_settings(args, literal_yaml=self.options.literal_yaml)
+            if self.options.cl_batch and self.options.cl_periodic:
+                print_("Can't set commitlog to be both batch and periodic.{}".format(os.linesep))
+                parser.print_help()
+                exit(1)
         except common.ArgumentError as e:
             print_(str(e), file=sys.stderr)
             exit(1)
@@ -615,7 +621,11 @@ class NodeUpdateconfCmd(Cmd):
                 self.setting['write_request_timeout_in_ms'] = self.options.rpc_timeout
                 self.setting['truncate_request_timeout_in_ms'] = self.options.rpc_timeout
                 self.setting['request_timeout_in_ms'] = self.options.rpc_timeout
-        self.node.set_configuration_options(values=self.setting, batch_commitlog=self.options.cl_batch)
+        self.node.set_configuration_options(values=self.setting)
+        if self.options.cl_batch:
+            self.node.set_batch_commitlog(True)
+        if self.options.cl_periodic:
+            self.node.set_batch_commitlog(False)
 
 class NodeUpdatedseconfCmd(Cmd):
 

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -232,7 +232,7 @@ class Node(object):
         version = self.get_cassandra_version()
         return float(version[:version.index('.') + 2])
 
-    def set_configuration_options(self, values=None, batch_commitlog=None):
+    def set_configuration_options(self, values=None):
         """
         Set Cassandra configuration options.
         ex:
@@ -240,23 +240,31 @@ class Node(object):
                 'hinted_handoff_enabled' : True,
                 'concurrent_writes' : 64,
             })
-        The batch_commitlog option gives an easier way to switch to batch
-        commitlog (since it requires setting 2 options and unsetting one).
         """
         if values is not None:
             for k, v in iteritems(values):
                 self.__config_options[k] = v
-        if batch_commitlog is not None:
-            if batch_commitlog:
-                self.__config_options["commitlog_sync"] = "batch"
-                self.__config_options["commitlog_sync_batch_window_in_ms"] = 5
-                self.__config_options["commitlog_sync_period_in_ms"] = None
-            else:
-                self.__config_options["commitlog_sync"] = "periodic"
-                self.__config_options["commitlog_sync_period_in_ms"] = 10000
-                self.__config_options["commitlog_sync_batch_window_in_ms"] = None
 
         self.import_config_files()
+
+    def set_batch_commitlog(self, enabled=False):
+        """
+        The batch_commitlog option gives an easier way to switch to batch
+        commitlog (since it requires setting 2 options and unsetting one).
+        """
+        if enabled:
+            values = {
+                "commitlog_sync" : "batch",
+                "commitlog_sync_batch_window_in_ms" : 5,
+                "commitlog_sync_period_in_ms" : None
+            }
+        else:
+            values = {
+                "commitlog_sync" : "periodic",
+                "commitlog_sync_batch_window_in_ms" : 10000,
+                "commitlog_sync_period_in_ms" : None
+            }
+        self.set_configuration_options(values)
 
     def set_dse_configuration_options(self, values=None):
         pass


### PR DESCRIPTION
@mambocab, please review this as well.

Connected with https://github.com/riptano/cassandra-dtest/pull/1002

Cassci test: http://cassci.datastax.com/view/Dev/view/smccarthy788/job/smccarthy788-cassandra-3.0-dtest/lastCompletedBuild/