### PR TITLE
Cstar 97

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -255,7 +255,7 @@ class _NodeToolCmd(Cmd):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
 
     def run(self):
-        stdout, stderr = self.node.nodetool(self.nodetool_cmd + " " + " ".join((self.args[1:])))
+        stdout, stderr, rc = self.node.nodetool(self.nodetool_cmd + " " + " ".join((self.args[1:])))
         print_(stderr)
         print_(stdout)
 
@@ -265,7 +265,7 @@ class NodeNodetoolCmd(_NodeToolCmd):
     descr_text = "Run nodetool (connecting to node name)"
 
     def run(self):
-        stdout, stderr = self.node.nodetool(" ".join(self.args[1:]))
+        stdout, stderr, rc = self.node.nodetool(" ".join(self.args[1:]))
         print_(stderr)
         print_(stdout)
 
@@ -392,7 +392,7 @@ class NodeCqlshCmd(Cmd):
         self.cqlsh_options = parser.get_ignored() + args[1:]
 
     def run(self):
-        self.node.run_cqlsh(self.options.cmds, self.options.verbose, self.cqlsh_options)
+        self.node.run_cqlsh(self.options.cmds, self.cqlsh_options)
 
 
 class NodeBulkloadCmd(Cmd):

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -13,7 +13,7 @@ import yaml
 from six import print_,iteritems
 
 from ccmlib import common, extension
-from ccmlib.node import Node, NodeError, NodetoolError
+from ccmlib.node import Node, NodeError, ToolError
 
 
 class DseNode(Node):
@@ -191,7 +191,7 @@ class DseNode(Node):
         if wait:
             exit_status = p.wait()
             if exit_status != 0:
-                raise NodetoolError(" ".join(args), exit_status, stdout, stderr)
+                raise ToolError(" ".join(args), exit_status, stdout, stderr)
 
         return stdout, stderr
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if system() == "Windows":
 
 setup(
     name='ccm',
-    version='2.2.1',
+    version='2.3.0',
     description='Cassandra Cluster Manager',
     long_description=open(abspath(join(dirname(__file__), 'README.md'))).read(),
     author='Sylvain Lebresne',


### PR DESCRIPTION
@ptnapoleon, @mambocab: I started with nodetool, making the assumption capture_output & wait will always be true. If we capture output we let callers use or ignore stdout / stderr & check the return code. Waiting lets us check for errors. 

All of the other changes follow along generally like this: create the process, communicate, return stdout, stderr, and rc.

The return values will be (stdout, stderr, and returncode) (except for nodetool, which checks rc internally). Return values should be placed inside a tuple to make it easy for callers to ignore some. I like these more than returning the process object from Popen().

Some methods (e.g. run_sstablesplit, run_sstablemetadata, etc) create a number of different subprocesses. The resulting (stdout, stderr, rc) tuples are packaged into a result list, and returned.

Thoughts?