### PR TITLE
Fix mkdir() call in Node._update_config()

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1337,7 +1337,7 @@ class Node(object):
         if not os.path.exists(dir_name):
             os.mkdir(dir_name)
             for dir in self._get_directories():
-                os.mkdir(os.path.join(dir_name, dir))
+                os.mkdir(dir)
 
         filename = os.path.join(dir_name, 'node.conf')
         values = {


### PR DESCRIPTION
The Node._get_directories() function already prepends the node root path
returned by get_path(). Therefore, fix up the mkdir() call not to
prepend the same directory again.

Fixes the following error in when running the test snippet from README:

  $ ./test.py
  Traceback (most recent call last):
    File "./test.py", line 11, in <module>
      cluster.populate(3).start()
    File "/home/penberg/ccm/ccmlib/cluster.py", line 223, in populate
      binary_interface=binary)
    File "/home/penberg/ccm/ccmlib/cluster.py", line 229, in create_node
      return Node(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port)
    File "/home/penberg/ccm/ccmlib/node.py", line 110, in __init__
      self.import_config_files()
    File "/home/penberg/ccm/ccmlib/node.py", line 1250, in import_config_files
      self._update_config()
    File "/home/penberg/ccm/ccmlib/node.py", line 1340, in _update_config
      os.mkdir(os.path.join(dir_name, dir))
  FileNotFoundError: [Errno 2] No such file or directory: './test/node1/./test/node1/commitlogs'