### PR TITLE
make log watching more amenable to resource cleanup

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -152,23 +152,23 @@ class Cluster(object):
 
                 return errordata
 
+            def scan_and_report(self):
+                errordata = self.scan()
+
+                if errordata:
+                    on_error_call(errordata)
+
             def run(self):
                 print_("Log-watching thread starting.")
 
                 # run until stop gets requested by .join()
                 while not self.req_stop_event.is_set():
-                    errordata = self.scan()
-
-                    if errordata:
-                        on_error_call(errordata)
-
+                    self.scan_and_report()
                     time.sleep(interval)
 
                 try:
                     # do a final scan to make sure we got to the very end of the files
-                    errordata = self.scan()
-                    if errordata:
-                        on_error_call(errordata)
+                    self.scan_and_report()
                 finally:
                     print_("Log-watching thread exiting.")
                     # done_event signals that the scan completed a final pass

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -132,8 +132,14 @@ class Cluster(object):
 
                 try:
                     for node in self.cluster.nodelist():
-                        errors = node.grep_log_for_errors_from(seek_start=self.log_positions[node.name])
-                        self.log_positions[node.name] = node.mark_log()
+                        scan_from_mark = self.log_positions[node.name]
+                        next_time_scan_from_mark = node.mark_log()
+                        if (next_time_scan_from_mark == scan_from_mark):
+                            # log hasn't advanced, nothing to do for this node
+                            continue
+                        else:
+                            errors = node.grep_log_for_errors_from(seek_start=scan_from_mark)
+                        self.log_positions[node.name] = next_time_scan_from_mark
                         if errors:
                             errordata[node.name] = errors
                 except IOError as e:

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -106,9 +106,11 @@ class Cluster(object):
 
     def actively_watch_logs_for_error(self, on_error_call, interval=1):
         """
-        Begins a thread that scans system.log for errors every interval seconds.
+        Begins a thread that repeatedly scans system.log for new errors, every interval seconds.
+        (The first pass covers the entire log contents written at that point,
+        subsequent scans cover newly appended log messages).
 
-        If an error is seen, the callback is executed with an OrderedDictionary
+        Reports new errors, by calling the provided callback with an OrderedDictionary
         mapping node name to a list of error lines.
 
         Returns the thread itself, which should be .join()'ed to wrap up execution,

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -159,7 +159,7 @@ class Cluster(object):
                     on_error_call(errordata)
 
             def run(self):
-                print_("Log-watching thread starting.")
+                common.debug("Log-watching thread starting.")
 
                 # run until stop gets requested by .join()
                 while not self.req_stop_event.is_set():
@@ -170,7 +170,7 @@ class Cluster(object):
                     # do a final scan to make sure we got to the very end of the files
                     self.scan_and_report()
                 finally:
-                    print_("Log-watching thread exiting.")
+                    common.debug("Log-watching thread exiting.")
                     # done_event signals that the scan completed a final pass
                     self.done_event.set()
 

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -106,7 +106,7 @@ class Cluster(object):
 
     def actively_watch_logs_for_error(self, on_error_call, interval=1):
         """
-        Begins a thread that scans logs for errors every interval seconds.
+        Begins a thread that scans system.log for errors every interval seconds.
 
         If an error is seen, the callback is executed with an OrderedDictionary
         mapping node name to a list of error lines.

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -172,7 +172,7 @@ class Cluster(object):
                 # signals to the main run() loop that a stop is requested
                 self.req_stop_event.set()
                 # now wait for the main loop to get through a final log scan, and signal that it's done
-                self.done_event.wait()
+                self.done_event.wait(timeout=interval*2)  # need to wait at least interval seconds before expecting thread to finish. 2x for safety.
                 super(LogWatchingThread, self).join(timeout)
 
         log_watcher = LogWatchingThread(self)


### PR DESCRIPTION
the main gist here, is now hand back a full-fledged thread to the caller who can .join() the thread when they are done watching logs (typically after cluster stop, but before file cleanup).