### PR TITLE
Fix issue when DSE nodes are removed/cleaned and ds agent is not installed

### DIFF
--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -501,16 +501,16 @@ class DseNode(Node):
         agent_dir = os.path.join(self.get_path(), 'datastax-agent')
         if os.path.exists(agent_dir):
             pidfile = os.path.join(agent_dir, 'datastax-agent.pid')
-        if os.path.exists(pidfile):
-            with open(pidfile, 'r') as f:
-                pid = int(f.readline().strip())
-                f.close()
-            if pid is not None:
-                try:
-                    os.kill(pid, signal.SIGKILL)
-                except OSError:
-                    pass
-            os.remove(pidfile)
+            if os.path.exists(pidfile):
+                with open(pidfile, 'r') as f:
+                    pid = int(f.readline().strip())
+                    f.close()
+                if pid is not None:
+                    try:
+                        os.kill(pid, signal.SIGKILL)
+                    except OSError:
+                        pass
+                os.remove(pidfile)
 
     def _write_agent_address_yaml(self, agent_dir):
         address_yaml = os.path.join(agent_dir, 'conf', 'address.yaml')


### PR DESCRIPTION
Variable `pidfile` is defined, when the DS agent directory is evaluated.
However, if the agent is not installed, `pidfile` is not defined, which leads to an error.

Unsure though, whether it's an error that the agent was not installed (used DSE 5 + OpsC 6).