### PR TITLE
Validate node name on cmdline node add so that we don't mess up the state on node initialization

### DIFF
--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -254,6 +254,11 @@ class ClusterAddCmd(Cmd):
             parser.print_help()
             exit(1)
 
+        if self.name in self.cluster.nodes:
+            print_("This name is already in use. Choose another.", file=sys.stderr)
+            parser.print_help()
+            exit(1)
+
         used_jmx_ports = [node.jmx_port for node in self.cluster.nodelist()]
         if options.jmx_port in used_jmx_ports:
             print_("This JMX port is already in use. Choose another.", file=sys.stderr)


### PR DESCRIPTION
When we add a node on the command line, if we duplicate the name of an existing node, it blows away state on disk in the node constructor but then fails to add the node to the cluster when the cluster validates the name.

There isn't a clear way I can see to disentangle this sequence without reworking the whole cluster/node abstraction. For now, we can duplicate the name check so that fat fingering a node name doesn't mess things up too badly.