### PR TITLE
use clock for timeout, not a counter

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -709,13 +709,11 @@ class Node(object):
         Wait for all compactions to finish on this node.
         """
         pattern = re.compile("pending tasks: 0")
-        elapsed = 0
-        while elapsed < timeout:
+        start = time.time()
+        while time.time() - start < timeout:
             output, err = self.nodetool("compactionstats", capture_output=True)
             if pattern.search(output):
                 return
-            elapsed += 1
-            time.sleep(1)
         raise TimeoutError("{} [{}] Compactions did not finish in {} seconds".format(time.strftime("%d %b %Y %H:%M:%S", time.gmtime()), self.name, timeout))
 
     def nodetool(self, cmd, capture_output=True, wait=True):


### PR DESCRIPTION
I've run this against the code from [this pr](https://github.com/riptano/cassandra-dtest/pull/1086), and it seems to work.