### PR TITLE
allow for an empty string to be represented as the default pattern

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -99,7 +99,7 @@ class LogPatternToVersion(object):
     @property
     def patterns(self):
         patterns = list(self.versions_to_patterns.values())
-        if self.default_pattern:
+        if self.default_pattern is not None:
             patterns = patterns + [self.default_pattern]
         return patterns
 


### PR DESCRIPTION
@ptnapoleon, @knifewine: I think this should address the issue raised in https://github.com/riptano/cassandra-dtest/pull/1311#issuecomment-246747914

We should be able to get the default pattern if it is falsy, but exists.