### PR TITLE
allow for verbose cli. pep8 clean

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -55,6 +55,7 @@ NODE_CMDS = [
     "byteman"
 ]
 
+
 def node_cmds():
     return NODE_CMDS
 
@@ -370,7 +371,12 @@ class NodeCliCmd(Cmd):
         self.cli_options = parser.get_ignored() + args[1:]
 
     def run(self):
-        self.node.run_cli(self.options.cmds, self.options.verbose, self.cli_options)
+        out, err, rc = self.node.run_cli(self.options.cmds, self.cli_options)
+        if self.options.verbose:
+            print "CLI OUTPUT:\n\n"
+            print out
+            print "\nCLI ERROR:\n\n"
+            print err
 
 
 class NodeCqlshCmd(Cmd):
@@ -490,10 +496,10 @@ class NodeJsonCmd(Cmd):
                                            enumerate_keys=self.options.enumerate_keys)
             elif self.node.has_cmd('sstabledump'):
                 self.node.run_sstabledump(keyspace=self.keyspace,
-                                           output_file=f,
-                                           column_families=self.column_families,
-                                           keys=self.options.keys,
-                                           enumerate_keys=self.options.enumerate_keys)
+                                          output_file=f,
+                                          column_families=self.column_families,
+                                          keys=self.options.keys,
+                                          enumerate_keys=self.options.enumerate_keys)
         except common.ArgumentError as e:
             print_(e, file=sys.stderr)
 
@@ -628,6 +634,7 @@ class NodeUpdateconfCmd(Cmd):
         if self.options.cl_periodic:
             self.node.set_batch_commitlog(False)
 
+
 class NodeUpdatedseconfCmd(Cmd):
 
     def description(self):
@@ -656,6 +663,7 @@ class NodeUpdatedseconfCmd(Cmd):
 # on the given node by copying the given config into
 # ~/.ccm/name-of-cluster/nodeX/conf/log4j-server.properties
 #
+
 
 class NodeUpdatelog4jCmd(Cmd):
 

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -373,10 +373,10 @@ class NodeCliCmd(Cmd):
     def run(self):
         out, err, rc = self.node.run_cli(self.options.cmds, self.cli_options)
         if self.options.verbose:
-            print "CLI OUTPUT:\n-------------------------------"
-            print out
-            print "-------------------------------\nCLI ERROR:\n-------------------------------"
-            print err
+            print_("CLI OUTPUT:\n-------------------------------")
+            print_(out)
+            print_("-------------------------------\nCLI ERROR:\n-------------------------------")
+            print_(err)
 
 
 class NodeCqlshCmd(Cmd):

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -373,9 +373,9 @@ class NodeCliCmd(Cmd):
     def run(self):
         out, err, rc = self.node.run_cli(self.options.cmds, self.cli_options)
         if self.options.verbose:
-            print "CLI OUTPUT:\n\n"
+            print "CLI OUTPUT:\n-------------------------------"
             print out
-            print "\nCLI ERROR:\n\n"
+            print "-------------------------------\nCLI ERROR:\n-------------------------------"
             print err
 
 


### PR DESCRIPTION
@ptnapoleon, I found a little bug. Trying to run `ccm node1 cli` would result in an argument error, since the `run_cli` method doesn't take the `verbose` argument anymore.

I'm happy to bikeshed over how this output is printed.