### PR TITLE
make local slugs better

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -47,7 +47,7 @@ def setup(version, verbose=False):
         version_dir = version_directory(version)
 
         if version_dir is None:
-            raise CCMError("Path provided in local slug appears invalid.")
+            raise CCMError("Path provided in local slug appears invalid ({})".format(path))
         return (version_dir, None)
 
     elif version.startswith('binary:'):

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -27,7 +27,6 @@ OPSC_ARCHIVE = "http://downloads.datastax.com/community/opscenter-%s.tar.gz"
 ARCHIVE = "http://archive.apache.org/dist/cassandra"
 GIT_REPO = "http://git-wip-us.apache.org/repos/asf/cassandra.git"
 GITHUB_TAGS = "https://api.github.com/repos/apache/cassandra/git/refs/tags"
-LOCAL_GIT_REPO = os.environ.get('LOCAL_GIT_REPO', None)  # absolute path to local cassandra git repo, e.g. /home/user/cassandra/
 
 
 def setup(version, verbose=False):
@@ -37,12 +36,19 @@ def setup(version, verbose=False):
     if version.startswith('git:'):
         clone_development(GIT_REPO, version, verbose=verbose)
         return (version_directory(version), None)
-
     elif version.startswith('local:'):
-        if LOCAL_GIT_REPO is None:
-            raise CCMError("LOCAL_GIT_REPO is not defined!")
-        clone_development(LOCAL_GIT_REPO, version, verbose=verbose)
-        return (version_directory(version), None)
+        # local: slugs take the form of: "local:/some/path/:somebranch"
+        try:
+            _, path, branch = version.split(':')
+        except ValueError:
+            raise CCMError("local version ({}) appears to be invalid. Please format as local:/some/path/:somebranch".format(version))
+
+        clone_development(path, version, verbose=verbose)
+        version_dir = version_directory(version)
+
+        if version_dir is None:
+            raise CCMError("Path provided in local slug appears invalid.")
+        return (version_dir, None)
 
     elif version.startswith('binary:'):
         version = version.replace('binary:', '')
@@ -112,8 +118,8 @@ def clone_development(git_repo, version, verbose=False):
     if 'github' in version:
         git_repo_name, git_branch = github_username_and_branch_name(version)
     elif 'local:' in version:
-        git_repo_name = 'local'
-        git_branch = version.split(':', 1)[1]
+        git_repo_name = 'local_{}'.format(git_repo)  # add git repo location to distinguish cache location for differing repos
+        git_branch = version.split(':')[-1]  # last token on 'local:...' slugs should always be branch name
     else:
         git_repo_name = 'apache'
         git_branch = version.split(':', 1)[1]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from os.path import abspath, join, dirname
+from os.path import abspath, dirname, join
 from platform import system
 from shutil import copyfile
 
@@ -16,7 +16,7 @@ if system() == "Windows":
 
 setup(
     name='ccm',
-    version='2.4.2',
+    version='2.4.3',
     description='Cassandra Cluster Manager',
     long_description=open(abspath(join(dirname(__file__), 'README.md'))).read(),
     author='Sylvain Lebresne',


### PR DESCRIPTION
This proposes to remove the old form of local:somebranch (requiring LOCAL_GIT_REPO defined in env) and replacing it with a form of local:/some/path/:branch_name . This is to support more easily working with multiple local versions across the filesystem (in multiple git repos). The old way made it clumsy to do that.

I tested this by hand locally and it appears to function well from the command line. If there's any specific cases you can think of I'm happy to test more.

I think the changes here have a low risk outside of local: usage.