### PR TITLE
add version_slug to cluster config

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -32,6 +32,7 @@ class Cluster(object):
         self.__log_level = "INFO"
         self.__path = path
         self.__version = None
+        self._version_slug = version
         self.use_vnodes = False
         # Classes that are to follow the respective logging level
         self._debug = []
@@ -588,6 +589,7 @@ class Cluster(object):
         config_map = {
             'name': self.name,
             'nodes': node_list,
+            'version_slug': self._version_slug,
             'seeds': seed_list,
             'partitioner': self.partitioner,
             'install_dir': self.__install_dir,

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -21,12 +21,13 @@ class ClusterFactory():
             data = yaml.load(f)
         try:
             install_dir = None
+            version_slug = data.get('version_slug', data.get('install_dir'))
             if 'install_dir' in data:
                 install_dir = data['install_dir']
-                repository.validate(install_dir)
+                repository.validate(install_dir, version_slug)
             if install_dir is None and 'cassandra_dir' in data:
                 install_dir = data['cassandra_dir']
-                repository.validate(install_dir)
+                repository.validate(install_dir, version_slug)
 
             if common.isDse(install_dir):
                 cluster = DseCluster(path, data['name'], install_dir=install_dir, create_directory=False)

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -654,8 +654,10 @@ def is_dse_cluster(path):
         return False
 
 
-def invalidate_cache():
-    rmdirs(os.path.join(get_default_path(), 'repository'))
+def invalidate_cache(repository_path=None):
+    if repository_path is None:
+        repository_path = os.path.join(get_default_path(), 'repository')
+    rmdirs(repository_path)
 
 
 def get_jdk_version():

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -105,10 +105,9 @@ def setup_opscenter(opscenter, verbose=False):
     return odir
 
 
-def validate(path):
+def validate(path, version_slug):
     if path.startswith(__get_dir()):
-        _, version = os.path.split(os.path.normpath(path))
-        setup(version)
+        setup(version_slug)
 
 
 def clone_development(git_repo, version, verbose=False):

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -1,0 +1,42 @@
+from unittest import TestCase
+import os
+import shutil
+from errno import ENOENT
+
+from ccmlib.cluster import Cluster
+from ccmlib import common
+from ccmlib.cluster_factory import ClusterFactory
+
+
+def rmtree_if_exists(path):
+    try:
+        shutil.rmtree(path)
+    except OSError as e:
+        if e.errno != ENOENT:
+            raise
+
+
+class TestLoadWithNoCacheRepo(TestCase):
+    test_dir = '/tmp/no_cache_test/'
+    repository_path = os.path.join(test_dir, 'repository')
+
+    def setUp(self):
+        rmtree_if_exists(self.test_dir)
+
+        os.makedirs(self.repository_path)
+        self.addCleanup(rmtree_if_exists, self.repository_path)
+
+    def test_delete_cache_and_load(self):
+        cluster_name = self._testMethodName
+        Cluster(
+            path=self.test_dir,
+            name=cluster_name,
+            version='git:trunk',
+            create_directory=True,
+            verbose=True,
+        )
+        common.invalidate_cache(self.repository_path)
+
+        loaded_cluster = ClusterFactory.load(
+            self.test_dir, cluster_name
+        )


### PR DESCRIPTION
When the cached checkout for a cluster is deleted, the cluster gets stranded -- you can't load it up with `ClusterFactory.load` or even `Cluster.remove` it, because it needs a cached repo backing it to do so. This adds a version_slug value to the cluster config that allows CCM to recreate the cached repo when it needs to. The following code fails before this commit and succeeds after it:

```
cluster = Cluster(
    path=DEFAULT_PATH,
    name=CLUSTER_NAME,
    install_dir=os.path.join(DEFAULT_PATH, CLUSTER_NAME),
    version='git:trunk',
    create_directory=True,
    verbose=True,
)

common.invalidate_cache()

loaded_cluster = ClusterFactory.load(
    DEFAULT_PATH, CLUSTER_NAME
) # fails before this commit, passes after
```

or, from the command line, 

```
( ( set -x ; ccm create repro-cs743 -v git:trunk && ccm invalidatecache && ccm remove ) ; rm -rf ~/.ccm )
```

(The final `rm` isn't necessary for repro, but remove the ccm cache, which will be messed up if you run it before this commit.)

I want to add tests for this somewhere, and I'll do that tomorrow or early next week if this general approach looks good. @ptnapoleon?