### PR TITLE
Default to starting clusters with binary_proto=True

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -361,7 +361,7 @@ class Cluster(object):
             else:
                 node.show(only_status=True)
 
-    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False,
+    def start(self, no_wait=False, verbose=False, wait_for_binary_proto=True,
               wait_other_notice=True, jvm_args=None, profile_options=None,
               quiet_start=False, allow_root=False):
         if jvm_args is None:


### PR DESCRIPTION
Leaving node as false for now, since sometimes when we
start nodes, in dtest, we're doing so to expect them to fail.
But clusters should generally always work on startup. The case
where one wants an entire cluster to fail to start is an odd one

@mambocab to review

CI is generally good, so I just need a few changes to dtest for this to work