### PR TITLE
allow for user configured aliases

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -134,7 +134,7 @@ def clone_development(git_repo, version, verbose=False, alias=False):
         git_repo_name = 'local_{}'.format(git_repo)  # add git repo location to distinguish cache location for differing repos
         git_branch = version.split(':')[-1]  # last token on 'local:...' slugs should always be branch name
     elif alias:
-        git_repo_name = 'alias_{}'.format(version.split(':')[0])
+        git_repo_name = 'alias_{}'.format(version.split('/')[0].split(':')[-1])
         git_branch = version.split('/')[-1]
     else:
         git_repo_name = 'apache'

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -74,7 +74,7 @@ def setup(version, verbose=False):
             clone_development(git_repo, version, verbose=verbose, alias=True)
             return (directory_name(version), None)
         except ConfigParser.NoOptionError as e:
-            common.warning("Unable to find {} in configuration file.".format(alias))
+            common.warning("Unable to find alias {} in configuration file.".format(alias))
             raise e
 
     if version in ('stable', 'oldstable', 'testing'):


### PR DESCRIPTION
@mambocab & @ptnapoleon: please review.

Just a little tweak. I'm trying to allow users to define aliases of git urls in a configuration file. Seems easier than `-v git:smccarthy788/cassandra-fork` every time.

Config files should look like

```
alias_name = some.git.url
```

be located at `.ccm/config`, and can be used as `ccm create -v alias:alias_name ...`
