### PR TITLE
Don't include removed thrift options when running against C* 4.0

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -265,9 +265,12 @@ class Cluster(object):
             binary = None
             if self.cassandra_version() >= '1.2':
                 binary = (ipformat % i, 9042)
+            thrift = None
+            if self.cassandra_version() < '4':
+                thrift = (ipformat % i, 9160)
             node = self.create_node(name='node%s' % i,
                                     auto_bootstrap=False,
-                                    thrift_interface=(ipformat % i, 9160),
+                                    thrift_interface=thrift,
                                     storage_interface=(ipformat % i, 7000),
                                     jmx_port=str(7000 + i * 100),
                                     remote_debug_port=str(2000 + i * 100) if debug else str(0),

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -522,7 +522,7 @@ class Node(object):
 
         Emits a warning if not listening after 10 seconds.
         """
-        if self.cluster.version() < '4':
+        if self.cluster.version() >= '4':
             return;
 
         self.watch_log_for("Listening for thrift clients...", **kwargs)


### PR DESCRIPTION
This is to support https://issues.apache.org/jira/browse/CASSANDRA-11115, and work at least as far as cassandra-dtests are involved on 4.0. Hopefully this doesn't break anything for earlier versions.