### PR TITLE
Increase waiting time for protocols to 30 seconds

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -505,21 +505,21 @@ class Node(object):
         log for 'Starting listening for CQL clients' before checking for the
         interface to be listening.
 
-        Emits a warning if not listening after 10 seconds.
+        Emits a warning if not listening after 30 seconds.
         """
         if self.cluster.version() >= '1.2':
             self.watch_log_for("Starting listening for CQL clients", **kwargs)
 
         binary_itf = self.network_interfaces['binary']
-        if not common.check_socket_listening(binary_itf, timeout=10):
-            warnings.warn("Binary interface %s:%s is not listening after 10 seconds, node may have failed to start."
+        if not common.check_socket_listening(binary_itf, timeout=30):
+            warnings.warn("Binary interface %s:%s is not listening after 30 seconds, node may have failed to start."
                           % (binary_itf[0], binary_itf[1]))
 
     def wait_for_thrift_interface(self, **kwargs):
         """
         Waits for the Thrift interface to be listening.
 
-        Emits a warning if not listening after 10 seconds.
+        Emits a warning if not listening after 30 seconds.
         """
         if self.cluster.version() >= '4':
             return;
@@ -527,8 +527,8 @@ class Node(object):
         self.watch_log_for("Listening for thrift clients...", **kwargs)
 
         thrift_itf = self.network_interfaces['thrift']
-        if not common.check_socket_listening(thrift_itf, timeout=10):
-            warnings.warn("Thrift interface {}:{} is not listening after 10 seconds, node may have failed to start.".format(thrift_itf[0], thrift_itf[1]))
+        if not common.check_socket_listening(thrift_itf, timeout=30):
+            warnings.warn("Thrift interface {}:{} is not listening after 30 seconds, node may have failed to start.".format(thrift_itf[0], thrift_itf[1]))
 
     def get_launch_bin(self):
         cdir = self.get_install_dir()


### PR DESCRIPTION
Quite often, it takes 15 or 20 seconds for the CQL binary protocol to start listening when starting a node. I thought about adding a `--protocol-wait-timeout` option but I think the added value is very limited. Simply increasing the timeout to 30 seconds will probably handle most cases.