### PR TITLE
Add --force option to decommission for CASSANDRA-12510.

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -330,8 +330,14 @@ class NodeDecommissionCmd(_NodeToolCmd):
     nodetool_cmd = 'decommission'
     descr_text = "Run decommission on node name"
 
+    def get_parser(self):
+        parser = self._get_default_parser(self.usage, self.description())
+        parser.add_option('--force', action="store_true", dest="force",
+                help="Force decommission of this node even when it reduces the number of replicas to below configured RF.  Note: This is only relevant for C* 3.12+.", default=False)
+        return parser
+
     def run(self):
-        self.node.decommission()
+        self.node.decommission(force=self.options.force)
 
 
 class _DseToolCmd(Cmd):

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1309,8 +1309,11 @@ class Node(object):
     def cleanup(self):
         self.nodetool("cleanup")
 
-    def decommission(self):
-        self.nodetool("decommission")
+    def decommission(self, force=False):
+        cmd = 'decommission'
+        if force:
+            cmd += " --force"
+        self.nodetool(cmd)
         self.status = Status.DECOMMISSIONED
         self._update_config()
 


### PR DESCRIPTION
[CASSANDRA-12510](https://issues.apache.org/jira/browse/CASSANDRA-12510) introduces behavior that prevents a successful
decommission unless the number of remaining replicas meet the
replication factors of all keyspaces.  A new --force option was added to
bypass this behavior.  Added this option to the 'ccm decommission'
command.