### PR TITLE
Update dsetool to use node address and port

### DIFF
--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -175,8 +175,9 @@ class DseNode(Node):
     def dsetool(self, cmd):
         env = self.get_env()
         extension.append_to_client_env(self, env)
+        (node_ip, binary_port) = self.network_interfaces['binary']
         dsetool = common.join_bin(self.get_install_dir(), 'bin', 'dsetool')
-        args = [dsetool, '-h', 'localhost', '-j', str(self.jmx_port)]
+        args = [dsetool, '-h', node_ip, '-j', str(self.jmx_port), '-c', str(binary_port)]
         args += cmd.split()
         p = subprocess.Popen(args, env=env)
         p.wait()

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -175,7 +175,7 @@ class DseNode(Node):
     def dsetool(self, cmd):
         env = self.get_env()
         extension.append_to_client_env(self, env)
-        (node_ip, binary_port) = self.network_interfaces['binary']
+        node_ip, binary_port = self.network_interfaces['binary']
         dsetool = common.join_bin(self.get_install_dir(), 'bin', 'dsetool')
         args = [dsetool, '-h', node_ip, '-j', str(self.jmx_port), '-c', str(binary_port)]
         args += cmd.split()


### PR DESCRIPTION
dsetool previously always targeted localhost.  Since dsetool is a
node-specific command, it makes sense to use the ip address of the node.
In addition, also passes in the binary port to use in the event that it
is different than the default port (9042).