### PR TITLE
Allow sstabledump to print results from command

### DIFF
--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -525,9 +525,10 @@ class NodeJsonCmd(Cmd):
                                            enumerate_keys=self.options.enumerate_keys)
             elif self.node.has_cmd('sstabledump'):
                 self.node.run_sstabledump(keyspace=self.keyspace,
-                                           column_families=self.column_families,
-                                           keys=self.options.keys,
-                                           enumerate_keys=self.options.enumerate_keys)
+                                          column_families=self.column_families,
+                                          keys=self.options.keys,
+                                          enumerate_keys=self.options.enumerate_keys,
+                                          command=True)
         except common.ArgumentError as e:
             print_(e, file=sys.stderr)
 


### PR DESCRIPTION
This adds an additional parameter to the `run_sstabledump` method to allow the command to print it's results immediately rather than returning them in an array.

This changes lets `ccm node1 -k ks -c tb` work correctly on a >3.0 node while maintaining compatibility with the dtests that also use `run_sstabledump`