### PR TITLE
Closed open socket in check_socket_listening

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -507,6 +507,8 @@ def check_socket_listening(itf, timeout=60):
             sock.close()
             return True
         except socket.error:
+            if sock:
+                sock.close()
             # Try again in another 200ms
             time.sleep(.2)
             continue


### PR DESCRIPTION
Hi,

Sometimes the socket is left opened here. I'm seeing a bunch of these logs in python3 every time the function is called:

`ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('0.0.0.0', 43928)>`