### PR TITLE
Update config after setting datadirs so that it persists when populating nodes

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -85,6 +85,7 @@ class Cluster(object):
 
     def set_datadir_count(self, n):
         self.data_dir_count = int(n)
+        self._update_config()
         return self
 
     def set_install_dir(self, install_dir=None, version=None, verbose=False):


### PR DESCRIPTION
Hello, 

I noticed that when I create a cluster like so: 
ccm create test --datadirs=3 

After I populate the cluster with nodes, the nodes still come up with only 1 data directory (data0). Digging into it it looks like cluster.conf only has datadirs: 1, and that seems to be because when we first create the cluster after we set the number of datadirs we do not update cluster.conf. (See cluster_cmds.py:ClusterCreateCmd.run).

I believe this fixes it, feel free to let me know if there is any feedback. 

Thanks!