### PR TITLE
support custom build.properties

### DIFF
--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -372,6 +372,13 @@ def compile_version(version, target_dir, verbose=False):
 
     common.info("Compiling Cassandra {} ...".format(version))
     logger.info("--- Cassandra Build -------------------\n")
+
+    default_build_properties = os.path.join(common.get_default_path(), 'build.properties.default')
+    if os.path.exists(default_build_properties):
+        target_build_properties = os.path.join(target_dir, 'build.properties')
+        logger.info("Copying %s to %s\n" % (default_build_properties, target_build_properties))
+        shutil.copyfile(default_build_properties, target_build_properties)
+
     try:
         # Patch for pending Cassandra issue: https://issues.apache.org/jira/browse/CASSANDRA-5543
         # Similar patch seen with buildbot


### PR DESCRIPTION
this adds support for using maven mirrors for all c* builds:
```
→ cat ~/.ccm/build.properties.default
artifact.remoteRepository.central:     <my maven mirror>
artifact.remoteRepository.apache:      <my maven mirror>
```

manual test:
```
10:53:57,205 repository INFO --- Cassandra Build -------------------

10:53:57,205 repository INFO Copying /home/chris/.ccm/build.properties.default to /home/chris/.ccm/repository/githubCOLONapacheSLASHtrunk/build.properties

...

BUILD SUCCESSFUL
Total time: 59 seconds

10:54:56,756 repository INFO 
10:54:56,756 repository INFO 

--- cassandra/stress build ------------

Current cluster is now: test1
```