### PR TITLE
handle failure in dse shell-out methods

### DIFF
--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -13,7 +13,8 @@ import yaml
 from six import iteritems, print_
 
 from ccmlib import common, extension, repository
-from ccmlib.node import Node, NodeError, ToolError
+from ccmlib.node import (Node, NodeError, ToolError,
+                         handle_external_tool_process)
 
 
 class DseNode(Node):
@@ -180,7 +181,7 @@ class DseNode(Node):
         args = [dsetool, '-h', node_ip, '-j', str(self.jmx_port), '-c', str(binary_port)]
         args += cmd.split()
         p = subprocess.Popen(args, env=env)
-        p.wait()
+        return handle_external_tool_process(p, args)
 
     def dse(self, dse_options=None):
         if dse_options is None:
@@ -192,7 +193,7 @@ class DseNode(Node):
         args = [dse]
         args += dse_options
         p = subprocess.Popen(args, env=env)
-        p.wait()
+        return handle_external_tool_process(p, args)
 
     def hadoop(self, hadoop_options=None):
         if hadoop_options is None:
@@ -203,7 +204,7 @@ class DseNode(Node):
         args = [dse, 'hadoop']
         args += hadoop_options
         p = subprocess.Popen(args, env=env)
-        p.wait()
+        return handle_external_tool_process(p, args)
 
     def hive(self, hive_options=None):
         if hive_options is None:
@@ -214,7 +215,7 @@ class DseNode(Node):
         args = [dse, 'hive']
         args += hive_options
         p = subprocess.Popen(args, env=env)
-        p.wait()
+        return handle_external_tool_process(p, args)
 
     def pig(self, pig_options=None):
         if pig_options is None:
@@ -225,7 +226,7 @@ class DseNode(Node):
         args = [dse, 'pig']
         args += pig_options
         p = subprocess.Popen(args, env=env)
-        p.wait()
+        return handle_external_tool_process(p, args)
 
     def sqoop(self, sqoop_options=None):
         if sqoop_options is None:
@@ -236,7 +237,7 @@ class DseNode(Node):
         args = [dse, 'sqoop']
         args += sqoop_options
         p = subprocess.Popen(args, env=env)
-        p.wait()
+        return handle_external_tool_process(p, args)
 
     def spark(self, spark_options=None):
         if spark_options is None:
@@ -247,7 +248,7 @@ class DseNode(Node):
         args = [dse, 'spark']
         args += spark_options
         p = subprocess.Popen(args, env=env)
-        p.wait()
+        return handle_external_tool_process(p, args)
 
     def import_dse_config_files(self):
         self._update_config()

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -180,7 +180,7 @@ class DseNode(Node):
         dsetool = common.join_bin(self.get_install_dir(), 'bin', 'dsetool')
         args = [dsetool, '-h', node_ip, '-j', str(self.jmx_port), '-c', str(binary_port)]
         args += cmd.split()
-        p = subprocess.Popen(args, env=env)
+        p = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return handle_external_tool_process(p, args)
 
     def dse(self, dse_options=None):
@@ -192,7 +192,7 @@ class DseNode(Node):
         dse = common.join_bin(self.get_install_dir(), 'bin', 'dse')
         args = [dse]
         args += dse_options
-        p = subprocess.Popen(args, env=env)
+        p = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return handle_external_tool_process(p, args)
 
     def hadoop(self, hadoop_options=None):
@@ -203,7 +203,7 @@ class DseNode(Node):
         dse = common.join_bin(self.get_install_dir(), 'bin', 'dse')
         args = [dse, 'hadoop']
         args += hadoop_options
-        p = subprocess.Popen(args, env=env)
+        p = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return handle_external_tool_process(p, args)
 
     def hive(self, hive_options=None):
@@ -214,7 +214,7 @@ class DseNode(Node):
         dse = common.join_bin(self.get_install_dir(), 'bin', 'dse')
         args = [dse, 'hive']
         args += hive_options
-        p = subprocess.Popen(args, env=env)
+        p = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return handle_external_tool_process(p, args)
 
     def pig(self, pig_options=None):
@@ -225,7 +225,7 @@ class DseNode(Node):
         dse = common.join_bin(self.get_install_dir(), 'bin', 'dse')
         args = [dse, 'pig']
         args += pig_options
-        p = subprocess.Popen(args, env=env)
+        p = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return handle_external_tool_process(p, args)
 
     def sqoop(self, sqoop_options=None):
@@ -236,7 +236,7 @@ class DseNode(Node):
         dse = common.join_bin(self.get_install_dir(), 'bin', 'dse')
         args = [dse, 'sqoop']
         args += sqoop_options
-        p = subprocess.Popen(args, env=env)
+        p = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return handle_external_tool_process(p, args)
 
     def spark(self, spark_options=None):
@@ -247,7 +247,7 @@ class DseNode(Node):
         dse = common.join_bin(self.get_install_dir(), 'bin', 'dse')
         args = [dse, 'spark']
         args += spark_options
-        p = subprocess.Popen(args, env=env)
+        p = subprocess.Popen(args, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return handle_external_tool_process(p, args)
 
     def import_dse_config_files(self):


### PR DESCRIPTION
This adds the handling added in #510 to DSE methods.

It's not clear to me how the C\* counterparts in `node.py` are tested. What should I do to test these changes? They work locally for me.

This is a breaking API change.