### PR TITLE
allow using nodes option for stress

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -484,10 +484,15 @@ class Cluster(object):
         if len(livenodes) == 0:
             print_("No live node")
             return
+        nodes_options = []
         if self.cassandra_version() <= '2.1':
-            args = [stress, '-d', ",".join(livenodes)] + stress_options
+            if '-d' not in stress_options:
+                nodes_options = ['-d', ",".join(livenodes)]
+            args = [stress] + nodes_options + stress_options
         else:
-            args = [stress] + stress_options + ['-node', ','.join(livenodes)]
+            if '-node' not in stress_options:
+                nodes_options = ['-node', ','.join(livenodes)]
+            args = [stress] + stress_options + nodes_options
         try:
             # need to set working directory for env on Windows
             if common.is_win():

--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -493,15 +493,16 @@ class Cluster(object):
             if '-node' not in stress_options:
                 nodes_options = ['-node', ','.join(livenodes)]
             args = [stress] + stress_options + nodes_options
+        rc = None
         try:
             # need to set working directory for env on Windows
             if common.is_win():
-                subprocess.call(args, cwd=common.parse_path(stress))
+                rc = subprocess.call(args, cwd=common.parse_path(stress))
             else:
-                subprocess.call(args)
+                rc = subprocess.call(args)
         except KeyboardInterrupt:
             pass
-        return self
+        return rc
 
     def run_cli(self, cmds=None, show_output=False, cli_options=None):
         if cli_options is None:

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -704,9 +704,11 @@ class ClusterStressCmd(Cmd):
 
     def run(self):
         try:
-            self.cluster.stress(self.stress_options)
+            rc = self.cluster.stress(self.stress_options)
+            exit(rc)
         except Exception as e:
             print_(e, file=sys.stderr)
+            exit(1)
 
 
 class ClusterUpdateconfCmd(Cmd):


### PR DESCRIPTION
it was not possible to give a custom nodes parameter to stress, because all live nodes are added all the time.

before:
```
→ ccm status test1                                           
Cluster: 'test1'
----------------
node1: UP
node3: UP
node2: UP

# chris in ~/code/ccm on git:master ✖︎ [9:21:54]
→ ccm stress write n=1000 -node whitelist 127.0.0.1,127.0.0.2
-node is defined multiple times. Each option/command can be specified at most once.
Usage:      cassandra-stress <command> [options]
Help usage: cassandra-stress help <command>
...
```

after this PR it is possible:
```
# chris in ~/code/ccm on git:stress-nodes-options ✖︎ [9:19:20]
→ ccm status test1                                           
Cluster: 'test1'
----------------
node1: UP
node3: UP
node2: UP

# chris in ~/code/ccm on git:stress-nodes-options ✖︎ [9:19:40]
→ ccm stress write n=1000 -node whitelist 127.0.0.1,127.0.0.2
******************** Stress Settings ********************
...
Node:
  Nodes: [127.0.0.1, 127.0.0.2]
...
Total operation time      : 00:00:00

END

# chris in ~/code/ccm on git:stress-nodes-options ✖︎ [9:19:54]
→ ccm stress write n=1000                                    
******************** Stress Settings ********************
...
Node:
  Nodes: [127.0.0.1, 127.0.0.3, 127.0.0.2]
...
type       total ops,    op/s,    pk/s,   row/s,    mean,     med,     .95,     .99,    .999,     max,   time,   stderr, errors,  gc: #,  max ms,  sum ms,  sdv ms,      mb
total,           285,     285,     285,     285,    12.9,     9.7,    33.7,    47.3,    57.6,    57.6,    1.0,  0.00000,      0,      0,       0,       0,       0,       0
total,          1000,    3401,    3401,    3401,    35.9,    28.9,    94.0,   125.0,   138.5,   143.3,    1.2,  0.66815,      0,      0,       0,       0,       0,       0
...
Total operation time      : 00:00:01

END
```

additionally before the stress cmd always exited with return code 0:
```
→ ccm stress write foo=1000; echo $?
Invalid parameter foo=1000
Usage:      cassandra-stress <command> [options]
Help usage: cassandra-stress help <command>
...
-tokenrange           : Token range settings
0
```

now it will correctly indicate an error:
```
→ ccm stress write foo=1000; echo $? 
Invalid parameter foo=1000
Usage:      cassandra-stress <command> [options]
Help usage: cassandra-stress help <command>
...
-tokenrange           : Token range settings
1

# chris in ~/code/ccm on git:stress-nodes-options ✖︎ [9:35:04]
→ ccm stress write n=1000; echo $?
******************** Stress Settings ********************
...
Total operation time      : 00:00:00

END
0
```