### PR TITLE
Fix indentation in _stop_agent

### DIFF
--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -154,16 +154,16 @@ class DseNode(Node):
         agent_dir = os.path.join(self.get_path(), 'datastax-agent')
         if os.path.exists(agent_dir):
             pidfile = os.path.join(agent_dir, 'datastax-agent.pid')
-        if os.path.exists(pidfile):
-            with open(pidfile, 'r') as f:
-                pid = int(f.readline().strip())
-                f.close()
-            if pid is not None:
-                try:
-                    os.kill(pid, signal.SIGKILL)
-                except OSError:
-                    pass
-            os.remove(pidfile)
+            if os.path.exists(pidfile):
+                with open(pidfile, 'r') as f:
+                    pid = int(f.readline().strip())
+                    f.close()
+                if pid is not None:
+                    try:
+                        os.kill(pid, signal.SIGKILL)
+                    except OSError:
+                        pass
+                os.remove(pidfile)
 
     def nodetool(self, cmd, username=None, password=None, capture_output=True, wait=True):
         if password is not None:


### PR DESCRIPTION
Commit `f9c70c0` introduced an indentation error whereby the variable
pidfile was referenced without being defined. This solves issue #565, where
`ccm stop` fails upon calling `_stop_agent()`.