### PR TITLE
Set dsefs options if spark is a workload

### DIFF
--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -79,6 +79,11 @@ class DseNode(Node):
                                                'data_directories': [{'dir': os.path.join(self.get_path(), 'dsefs', 'data')}]}}
             self.set_dse_configuration_options(dsefs_options)
         if 'spark' in self.workloads:
+            dsefs_options = {'dsefs_options': {'enabled': False,
+                                               'work_dir': os.path.join(self.get_path(), 'dsefs'),
+                                               'data_directories': [
+                                                   {'dir': os.path.join(self.get_path(), 'dsefs', 'data')}]}}
+            self.set_dse_configuration_options(dsefs_options)
             self._update_spark_env()
 
     def set_dse_configuration_options(self, values=None):


### PR DESCRIPTION
This is failing to start after deleting `/var/lib/dsefs`, 
```
ccm create 5.1.2 -v 5.1.2 -n 3
ccm setworkload spark
ccm start
```

Looks like when starting spark the working dirs for dsefs are set to the default directory.