### PR TITLE
Refactor Cmd subclasses and ccm

### DIFF
--- a/ccm
+++ b/ccm
@@ -19,27 +19,27 @@ def get_command(kind, cmd):
     return klass()
 
 
+def print_subcommand_usage(kind):
+    for cmd_name in (cluster_cmds if kind.lower() == 'cluster' else node_cmds).commands():
+        cmd = get_command(kind, cmd_name)
+        if not cmd:
+            print_("Internal error, unknown command {0}".format(cmd_name))
+            exit(1)
+        print_("  {0:14} {1}".format(cmd_name, cmd.description()))
+
+
 def print_global_usage():
     print_("Usage:")
     print_("  ccm <cluster_cmd> [options]")
     print_("  ccm <node_name> <node_cmd> [options]")
     print_("")
     print_("Where <cluster_cmd> is one of")
-    for cmd_name in cluster_cmds.cluster_cmds():
-        cmd = get_command("cluster", cmd_name)
-        if not cmd:
-            print_("Internal error, unknown command {0}".format(cmd_name))
-            exit(1)
-        print_("  {0:14} {1}".format(cmd_name, cmd.description()))
+    print_subcommand_usage('cluster')
     print_("")
     print_("or <node_name> is the name of a node of the current cluster and <node_cmd> is one of")
-    for cmd_name in node_cmds.node_cmds():
-        cmd = get_command("node", cmd_name)
-        if not cmd:
-            print_("Internal error, unknown command {0}".format(cmd_name))
-            exit(1)
-        print_("  {0:14} {1}".format(cmd_name, cmd.description()))
+    print_subcommand_usage('node')
     exit(1)
+
 
 for entry_point in pkg_resources.iter_entry_points(group='ccm_extension'):
     entry_point.load()()
@@ -55,16 +55,16 @@ arg1 = sys.argv[1].lower()
 # show-*-cmds are undocumented commands that emit a list of
 # the appropriate type of subcommand. This is used by the bash completion script.
 if arg1 == 'show-cluster-cmds':
-    for cmd_name in cluster_cmds.cluster_cmds():
+    for cmd_name in cluster_cmds.commands():
         print_(cmd_name)
     exit(1)
 
 if arg1 == 'show-node-cmds':
-    for cmd_name in node_cmds.node_cmds():
+    for cmd_name in node_cmds.commands():
         print_(cmd_name)
     exit(1)
 
-if arg1 in cluster_cmds.cluster_cmds():
+if arg1 in cluster_cmds.commands():
     kind = 'cluster'
     cmd = arg1
     cmd_args = sys.argv[2:]

--- a/ccmlib/cmds/cluster_cmds.py
+++ b/ccmlib/cmds/cluster_cmds.py
@@ -65,7 +65,7 @@ def parse_populate_count(v):
 
 class ClusterCreateCmd(Cmd):
 
-    options = [
+    options_list = [
         (['--no-switch'], {'action': "store_true", 'dest': "no_switch", 'help': "Don't switch to the newly created cluster", 'default': False}),
         (['-p', '--partitioner'], {'type': "string", 'dest': "partitioner", 'help': "Set the cluster partitioner class"}),
         (['-v', "--version"], {'type': "string", 'dest': "version", 'help': "Download and use provided cassandra or dse version. If version is of the form 'git:<branch name>', then the specified cassandra branch will be downloaded from the git repo and compiled. (takes precedence over --install-dir)", 'default': None}),
@@ -191,7 +191,7 @@ class ClusterCreateCmd(Cmd):
 
 class ClusterAddCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-b', '--auto-bootstrap'], {'action': "store_true", 'dest': "bootstrap", 'help': "Set auto bootstrap for the node", 'default': False}),
         (['-s', '--seeds'], {'action': "store_true", 'dest': "is_seed", 'help': "Configure this node as a seed", 'default': False}),
         (['-i', '--itf'], {'type': "string", 'dest': "itfs", 'help': "Set host and port for thrift, the binary protocol and storage (format: host[:port])"}),
@@ -259,7 +259,7 @@ class ClusterAddCmd(Cmd):
 
 class ClusterPopulateCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-n', '--nodes'], {'type': "string", 'dest': "nodes", 'help': "Number of nodes to populate with (a single int or a colon-separate list of ints for multi-dc setups)"}),
         (['-d', '--debug'], {'action': "store_true", 'dest': "debug", 'help': "Enable remote debugging options", 'default': False}),
         (['--vnodes'], {'action': "store_true", 'dest': "vnodes", 'help': "Populate using vnodes", 'default': False}),
@@ -331,7 +331,7 @@ class ClusterSwitchCmd(Cmd):
 
 class ClusterStatusCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-v', '--verbose'], {'action': "store_true", 'dest': "verbose", 'help': "Print full information on all nodes", 'default': False}),
     ]
     descr_text = "Display status on the current cluster"
@@ -406,7 +406,7 @@ class ClusterLivesetCmd(Cmd):
 
 class ClusterSetdirCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-v', "--version"], {'type': "string", 'dest': "version", 'help': "Download and use provided cassandra or dse version. If version is of the form 'git:<branch name>', then the specified cassandra branch will be downloaded from the git repo and compiled. (takes precedence over --install-dir)", 'default': None}),
         (["--install-dir"], {'type': "string", 'dest': "install_dir", 'help': "Path to the cassandra or dse directory to use [default %default]", 'default': "./"}),
         (['-n', '--node'], {'type': "string", 'dest': "node", 'help': "Set directory only for the specified node"}),
@@ -445,7 +445,7 @@ class ClusterClearrepoCmd(Cmd):
 
 class ClusterStartCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-v', '--verbose'], {'action': "store_true", 'dest': "verbose", 'help': "Print standard output of cassandra process", 'default': False}),
         (['--no-wait'], {'action': "store_true", 'dest': "no_wait", 'help': "Do not wait for cassandra node to be ready. Overrides all other wait options.", 'default': False}),
         # This option (wait-other-notice) is now deprecated, as it was never respected
@@ -504,7 +504,7 @@ class ClusterStartCmd(Cmd):
 
 class ClusterStopCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-v', '--verbose'], {'action': "store_true", 'dest': "verbose", 'help': "Print nodes that were not running", 'default': False}),
         (['--no-wait'], {'action': "store_true", 'dest': "no_wait", 'help': "Do not wait for the node to be stopped", 'default': False}),
         (['-g', '--gently'], {'action': "store_const", 'dest': "signal_event", 'help': "Shut down gently (default)", 'const': signal.SIGTERM, 'default': signal.SIGTERM}),
@@ -581,7 +581,7 @@ class ClusterStressCmd(Cmd):
 
 class ClusterUpdateconfCmd(Cmd):
 
-    options = [
+    options_list = [
         (['--no-hh', '--no-hinted-handoff'], {'action': "store_false", 'dest': "hinted_handoff", 'default': True, 'help': "Disable hinted handoff"}),
         (['--batch-cl', '--batch-commit-log'], {'action': "store_true", 'dest': "cl_batch", 'default': None, 'help': "Set commit log to batch mode"}),
         (['--periodic-cl', '--periodic-commit-log'], {'action': "store_true", 'dest': "cl_periodic", 'default': None, 'help': "Set commit log to periodic mode"}),
@@ -625,7 +625,7 @@ class ClusterUpdateconfCmd(Cmd):
 
 class ClusterUpdatedseconfCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-y', '--yaml'], {'action': "store_true", 'dest': "literal_yaml", 'default': False, 'help': "Pass in literal yaml string. Option syntax looks like ccm updatedseconf -y 'a: [b: [c,d]]'"}),
     ]
     descr_text = "Update the dse config files for all nodes"
@@ -651,7 +651,7 @@ class ClusterUpdatedseconfCmd(Cmd):
 
 class ClusterUpdatelog4jCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-p', '--path'], {'type': "string", 'dest': "log4jpath", 'help': "Path to new Cassandra log4j configuration file"}),
     ]
     descr_text = "Update the Cassandra log4j-server.properties configuration file on all nodes"
@@ -681,7 +681,7 @@ class ClusterUpdatelog4jCmd(Cmd):
 
 class ClusterCliCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-x', '--exec'], {'type': "string", 'dest': "cmds", 'default': None, 'help': "Execute the specified commands and exit"}),
         (['-v', '--verbose'], {'action': "store_true", 'dest': "verbose", 'help': "With --exec, show cli output after completion", 'default': False}),
     ]
@@ -746,7 +746,7 @@ class ClusterVerifyCmd(Cmd):
 
 class ClusterSetlogCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-c', '--class'], {'type': "string", 'dest': "class_name", 'default': None, 'help': "Optional java class/package. Logging will be set for only this class/package if set"}),
     ]
     descr_text = "Set log level (INFO, DEBUG, ...) with/without Java class for all node of the cluster - require a node restart"

--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -43,7 +43,7 @@ class ForgivingParser(OptionParser):
 
 
 class Cmd(object):
-    options = []
+    options_list = []
     usage = ""
     descr_text = ""
     ignore_unknown_options = False
@@ -52,7 +52,7 @@ class Cmd(object):
         if self.usage == "":
             pass
         parser = self._get_default_parser(self.usage, self.description(), self.ignore_unknown_options)
-        for args, kwargs in self.options:
+        for args, kwargs in self.options_list:
             parser.add_option(*args, **kwargs)
         return parser
 

--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -43,9 +43,18 @@ class ForgivingParser(OptionParser):
 
 
 class Cmd(object):
+    options = []
+    usage = ""
+    descr_text = ""
+    ignore_unknown_options = False
 
     def get_parser(self):
-        pass
+        if self.usage == "":
+            pass
+        parser = self._get_default_parser(self.usage, self.description(), self.ignore_unknown_options)
+        for args, kwargs in self.options:
+            parser.add_option(*args, **kwargs)
+        return parser
 
     def validate(self, parser, options, args, cluster_name=False, node_name=False, load_cluster=False, load_node=True):
         self.options = options
@@ -93,7 +102,7 @@ class Cmd(object):
         return parser
 
     def description(self):
-        return ""
+        return self.descr_text
 
     def _load_current_cluster(self):
         name = common.current_cluster_name(self.path)

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -60,18 +60,14 @@ NODE_CMDS = [
 ]
 
 
-def node_cmds():
+def commands():
     return NODE_CMDS
 
 
 class NodeShowCmd(Cmd):
 
-    def description(self):
-        return "Display information on a node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name show [options]"
-        return self._get_default_parser(usage, self.description())
+    descr_text = "Display information on a node"
+    usage = "usage: ccm node_name show [options]"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -82,12 +78,8 @@ class NodeShowCmd(Cmd):
 
 class NodeRemoveCmd(Cmd):
 
-    def description(self):
-        return "Remove a node (stopping it if necessary and deleting all its data)"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name remove [options]"
-        return self._get_default_parser(usage, self.description())
+    descr_text = "Remove a node (stopping it if necessary and deleting all its data)"
+    usage = "usage: ccm node_name remove [options]"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -98,12 +90,8 @@ class NodeRemoveCmd(Cmd):
 
 class NodeShowlogCmd(Cmd):
 
-    def description(self):
-        return "Show the log of node name (runs your $PAGER on its system.log)"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name showlog [options]"
-        return self._get_default_parser(usage, self.description())
+    descr_text = "Show the log of node name (runs your $PAGER on its system.log)"
+    usage = "usage: ccm node_name showlog [options]"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -116,15 +104,11 @@ class NodeShowlogCmd(Cmd):
 
 class NodeSetlogCmd(Cmd):
 
-    def description(self):
-        return "Set node name log level (INFO, DEBUG, ...) with/without Java class - require a node restart"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name setlog [options] level"
-        parser = self._get_default_parser(usage, self.description())
-        parser.add_option('-c', '--class', type="string", dest="class_name", default=None,
-                          help="Optional java class/package. Logging will be set for only this class/package if set")
-        return parser
+    options = [
+        (['-c', '--class'], {'type': "string", 'dest': "class_name", 'default': None, 'help': "Optional java class/package. Logging will be set for only this class/package if set"}),
+    ]
+    descr_text = "Set node name log level (INFO, DEBUG, ...) with/without Java class - require a node restart"
+    usage = "usage: ccm node_name setlog [options] level"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -150,15 +134,11 @@ class NodeSetlogCmd(Cmd):
 
 class NodeClearCmd(Cmd):
 
-    def description(self):
-        return "Clear the node data & logs (and stop the node)"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name_clear [options]"
-        parser = self._get_default_parser(usage, self.description())
-        parser.add_option('-a', '--all', action="store_true", dest="all",
-                          help="Also clear the saved cache and node log files", default=False)
-        return parser
+    options = [
+        (['-a', '--all'], {'action': "store_true", 'dest': "all", 'help': "Also clear the saved cache and node log files", 'default': False}),
+    ]
+    descr_text = "Clear the node data & logs (and stop the node)"
+    usage = "usage: ccm node_name_clear [options]"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -170,31 +150,20 @@ class NodeClearCmd(Cmd):
 
 class NodeStartCmd(Cmd):
 
-    def description(self):
-        return "Start a node"
-
-    def get_parser(self):
-        usage = "usage: ccm node start [options] name"
-        parser = self._get_default_parser(usage, self.description())
-        parser.add_option('-v', '--verbose', action="store_true", dest="verbose",
-                          help="Print standard output of cassandra process", default=False)
-        parser.add_option('--no-wait', action="store_true", dest="no_wait",
-                          help="Do not wait for cassandra node to be ready", default=False)
-        parser.add_option('--wait-other-notice', action="store_true", dest="deprecate",
-                          help="DEPRECATED/IGNORED: Use '--skip-wait-other-notice' instead. This is now on by default.", default=False)
-        parser.add_option('--skip-wait-other-notice', action="store_false", dest="wait_other_notice",
-                          help="Skip waiting until all live nodes of the cluster have marked the other nodes UP", default=True)
-        parser.add_option('--wait-for-binary-proto', action="store_true", dest="wait_for_binary_proto",
-                          help="Wait for the binary protocol to start", default=False)
-        parser.add_option('-j', '--dont-join-ring', action="store_true", dest="no_join_ring",
-                          help="Launch the instance without joining the ring", default=False)
-        parser.add_option('--replace-address', type="string", dest="replace_address", default=None,
-                          help="Replace a node in the ring through the cassandra.replace_address option")
-        parser.add_option('--jvm_arg', action="append", dest="jvm_args",
-                          help="Specify a JVM argument", default=[])
-        parser.add_option('--quiet-windows', action="store_true", dest="quiet_start", help="Pass -q on Windows 2.2.4+ and 3.0+ startup. Ignored on linux.", default=False)
-        parser.add_option('--root', action="store_true", dest="allow_root", help="Allow CCM to start cassandra as root", default=False)
-        return parser
+    options = [
+        (['-v', '--verbose'], {'action': "store_true", 'dest': "verbose", 'help': "Print standard output of cassandra process", 'default': False}),
+        (['--no-wait'], {'action': "store_true", 'dest': "no_wait", 'help': "Do not wait for cassandra node to be ready", 'default': False}),
+        (['--wait-other-notice'], {'action': "store_true", 'dest': "deprecate", 'help': "DEPRECATED/IGNORED: Use '--skip-wait-other-notice' instead. This is now on by default.", 'default': False}),
+        (['--skip-wait-other-notice'], {'action': "store_false", 'dest': "wait_other_notice", 'help': "Skip waiting until all live nodes of the cluster have marked the other nodes UP", 'default': True}),
+        (['--wait-for-binary-proto'], {'action': "store_true", 'dest': "wait_for_binary_proto", 'help': "Wait for the binary protocol to start", 'default': False}),
+        (['-j', '--dont-join-ring'], {'action': "store_true", 'dest': "no_join_ring", 'help': "Launch the instance without joining the ring", 'default': False}),
+        (['--replace-address'], {'type': "string", 'dest': "replace_address", 'default': None, 'help': "Replace a node in the ring through the cassandra.replace_address option"}),
+        (['--jvm_arg'], {'action': "append", 'dest': "jvm_args", 'help': "Specify a JVM argument", 'default': []}),
+        (['--quiet-windows'], {'action': "store_true", 'dest': "quiet_start", 'help': "Pass -q on Windows 2.2.4+ and 3.0+ startup. Ignored on linux.", 'default': False}),
+        (['--root'], {'action': "store_true", 'dest': "allow_root", 'help': "Allow CCM to start cassandra as root", 'default': False}),
+    ]
+    descr_text = "Start a node"
+    usage = "usage: ccm node start [options] name"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -220,32 +189,14 @@ class NodeStartCmd(Cmd):
 
 class NodeStopCmd(Cmd):
 
-    def description(self):
-        return "Stop a node"
-
-    def get_parser(self):
-        usage = "usage: ccm node stop [options] name"
-        parser = self._get_default_parser(usage, self.description())
-        parser.add_option('--no-wait', action="store_true", dest="no_wait",
-                          help="Do not wait for the node to be stopped", default=False)
-        parser.add_option('-g', '--gently', action="store_const", dest="signal_event",
-                          help="Shut down gently (default)", const=signal.SIGTERM,
-                          default=signal.SIGTERM)
-
-        if common.is_win():
-            # Fill the dictionary with SIGTERM as the cluster is killed forcefully
-            # on Windows regardless of assigned signal (TASKKILL is used)
-            default_signal_events = { '1': signal.SIGTERM, '9': signal.SIGTERM }
-        else:
-            default_signal_events = { '1': signal.SIGHUP, '9': signal.SIGKILL }
-
-        parser.add_option('--hang-up', action="store_const", dest="signal_event",
-                          help="Shut down via hang up (kill -1)",
-                          const=default_signal_events['1'])
-        parser.add_option('--not-gently', action="store_const", dest="signal_event",
-                          help="Shut down immediately (kill -9)",
-                          const=default_signal_events['9'])
-        return parser
+    options = [
+        (['--no-wait'], {'action': "store_true", 'dest': "no_wait", 'help': "Do not wait for the node to be stopped", 'default': False}),
+        (['-g', '--gently'], {'action': "store_const", 'dest': "signal_event", 'help': "Shut down gently (default)", 'const': signal.SIGTERM, 'default': signal.SIGTERM}),
+        (['--hang-up'], {'action': "store_const", 'dest': "signal_event", 'help': "Shut down via hang up (kill -1)", 'const': common.get_default_signals()['1']}),
+        (['--not-gently'], {'action': "store_const", 'dest': "signal_event", 'help': "Shut down immediately (kill -9)", 'const': common.get_default_signals()['9']}),
+    ]
+    descr_text = "Stop a node"
+    usage = "usage: ccm node stop [options] name"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -264,13 +215,6 @@ class _NodeToolCmd(Cmd):
     usage = "This is a private class, how did you get here?"
     descr_text = "This is a private class, how did you get here?"
     nodetool_cmd = ''
-
-    def get_parser(self):
-        parser = self._get_default_parser(self.usage, self.description())
-        return parser
-
-    def description(self):
-        return self.descr_text
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -341,14 +285,11 @@ class NodeVersionCmd(_NodeToolCmd):
 
 class NodeDecommissionCmd(_NodeToolCmd):
     usage = "usage: ccm node_name decommission [options]"
+    options = [
+        (['--force'], {'action': "store_true", 'dest': "force", 'help': "Force decommission of this node even when it reduces the number of replicas to below configured RF.  Note: This is only relevant for C* 3.12+.", 'default': False}),
+    ]
     nodetool_cmd = 'decommission'
     descr_text = "Run decommission on node name"
-
-    def get_parser(self):
-        parser = self._get_default_parser(self.usage, self.description())
-        parser.add_option('--force', action="store_true", dest="force",
-                help="Force decommission of this node even when it reduces the number of replicas to below configured RF.  Note: This is only relevant for C* 3.12+.", default=False)
-        return parser
 
     def run(self):
         self.node.decommission(force=self.options.force)
@@ -358,13 +299,6 @@ class _DseToolCmd(Cmd):
     usage = "This is a private class, how did you get here?"
     descr_text = "This is a private class, how did you get here?"
     dsetool_cmd = ''
-
-    def get_parser(self):
-        parser = self._get_default_parser(self.usage, self.description())
-        return parser
-
-    def description(self):
-        return self.descr_text
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -387,17 +321,13 @@ class NodeDsetoolCmd(_DseToolCmd):
 
 class NodeCliCmd(Cmd):
 
-    def description(self):
-        return "Launch a cassandra cli connected to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name cli [options] [cli_options]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        parser.add_option('-x', '--exec', type="string", dest="cmds", default=None,
-                          help="Execute the specified commands and exit")
-        parser.add_option('-v', '--verbose', action="store_true", dest="verbose",
-                          help="With --exec, show cli output after completion", default=False)
-        return parser
+    options = [
+        (['-x', '--exec'], {'type': "string", 'dest': "cmds", 'default': None, 'help': "Execute the specified commands and exit"}),
+        (['-v', '--verbose'], {'action': "store_true", 'dest': "verbose", 'help': "With --exec, show cli output after completion", 'default': False}),
+    ]
+    descr_text = "Launch a cassandra cli connected to this node"
+    usage = "usage: ccm node_name cli [options] [cli_options]"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -414,17 +344,13 @@ class NodeCliCmd(Cmd):
 
 class NodeCqlshCmd(Cmd):
 
-    def description(self):
-        return "Launch a cqlsh session connected to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name cqlsh [options] [cli_options]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        parser.add_option('-x', '--exec', type="string", dest="cmds", default=None,
-                          help="Execute the specified commands and exit")
-        parser.add_option('-v', '--verbose', action="store_true", dest="verbose",
-                          help="With --exec, show cli output after completion", default=False)
-        return parser
+    options = [
+        (['-x', '--exec'], {'type': "string", 'dest': "cmds", 'default': None, 'help': "Execute the specified commands and exit"}),
+        (['-v', '--verbose'], {'action': "store_true", 'dest': "verbose", 'help': "With --exec, show cli output after completion", 'default': False}),
+    ]
+    descr_text = "Launch a cqlsh session connected to this node"
+    usage = "usage: ccm node_name cqlsh [options] [cli_options]"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -436,13 +362,9 @@ class NodeCqlshCmd(Cmd):
 
 class NodeBulkloadCmd(Cmd):
 
-    def description(self):
-        return "Bulkload files into the cluster by connecting to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name bulkload [options] [sstable_dir]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Bulkload files into the cluster by connecting to this node"
+    usage = "usage: ccm node_name bulkload [options] [sstable_dir]"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -454,13 +376,9 @@ class NodeBulkloadCmd(Cmd):
 
 class NodeScrubCmd(Cmd):
 
-    def description(self):
-        return "Scrub files"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name scrub [options] <keyspace> <cf>"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Scrub files"
+    usage = "usage: ccm node_name scrub [options] <keyspace> <cf>"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -472,13 +390,9 @@ class NodeScrubCmd(Cmd):
 
 class NodeVerifyCmd(Cmd):
 
-    def description(self):
-        return "Verify files"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name verify [options] <keyspace> <cf>"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Verify files"
+    usage = "usage: ccm node_name verify [options] <keyspace> <cf>"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -490,21 +404,14 @@ class NodeVerifyCmd(Cmd):
 
 class NodeJsonCmd(Cmd):
 
-    def description(self):
-        return "Call sstable2json/sstabledump on the sstables of this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name json [options] [file]"
-        parser = self._get_default_parser(usage, self.description())
-        parser.add_option('-k', '--keyspace', type="string", dest="keyspace", default=None,
-                          help="The keyspace to use [use all keyspaces by default]")
-        parser.add_option('-c', '--column-families', type="string", dest="cfs", default=None,
-                          help="Comma separated list of column families to use (requires -k to be set)")
-        parser.add_option('--key', type="string", action="append", dest="keys", default=None,
-                          help="The key to include (you may specify multiple --key)")
-        parser.add_option('-e', '--enumerate-keys', action="store_true", dest="enumerate_keys",
-                          help="Only enumerate keys (i.e, call sstable2keys)", default=False)
-        return parser
+    options = [
+        (['-k', '--keyspace'], {'type': "string", 'dest': "keyspace", 'default': None, 'help': "The keyspace to use [use all keyspaces by default]"}),
+        (['-c', '--column-families'], {'type': "string", 'dest': "cfs", 'default': None, 'help': "Comma separated list of column families to use (requires -k to be set)"}),
+        (['--key'], {'type': "string", 'action': "append", 'dest': "keys", 'default': None, 'help': "The key to include (you may specify multiple --key)"}),
+        (['-e', '--enumerate-keys'], {'action': "store_true", 'dest': "enumerate_keys", 'help': "Only enumerate keys (i.e, call sstable2keys)", 'default': False}),
+    ]
+    descr_text = "Call sstable2json/sstabledump on the sstables of this node"
+    usage = "usage: ccm node_name json [options] [file]"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -539,21 +446,14 @@ class NodeJsonCmd(Cmd):
 
 class NodeSstablesplitCmd(Cmd):
 
-    def description(self):
-        return "Run sstablesplit on the sstables of this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name sstablesplit [options] [file]"
-        parser = self._get_default_parser(usage, self.description())
-        parser.add_option('-k', '--keyspace', type="string", dest="keyspace", default=None,
-                          help="The keyspace to use [use all keyspaces by default]")
-        parser.add_option('-c', '--column-families', type="string", dest='cfs', default=None,
-                          help="Comma separated list of column families to use (requires -k to be set)")
-        parser.add_option('-s', '--size', type='int', dest="size", default=None,
-                          help="Maximum size in MB for the output sstables (default: 50 MB)")
-        parser.add_option('--no-snapshot', action='store_true', dest="no_snapshot", default=False,
-                          help="Don't snapshot the sstables before splitting")
-        return parser
+    options = [
+        (['-k', '--keyspace'], {'type': "string", 'dest': "keyspace", 'default': None, 'help': "The keyspace to use [use all keyspaces by default]"}),
+        (['-c', '--column-families'], {'type': "string", 'dest': 'cfs', 'default': None, 'help': "Comma separated list of column families to use (requires -k to be set)"}),
+        (['-s', '--size'], {'type': 'int', 'dest': "size", 'default': None, 'help': "Maximum size in MB for the output sstables (default: 50 MB)"}),
+        (['--no-snapshot'], {'action': 'store_true', 'dest': "no_snapshot", 'default': False, 'help': "Don't snapshot the sstables before splitting"}),
+    ]
+    descr_text = "Run sstablesplit on the sstables of this node"
+    usage = "usage: ccm node_name sstablesplit [options] [file]"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -582,17 +482,12 @@ class NodeSstablesplitCmd(Cmd):
 
 class NodeGetsstablesCmd(Cmd):
 
-    def description(self):
-        return "Run getsstables to get absolute path of sstables in this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name getsstables [options] [file]"
-        parser = self._get_default_parser(usage, self.description())
-        parser.add_option('-k', '--keyspace', type="string", dest="keyspace", default=None,
-                          help="The keyspace to use [use all keyspaces by default]")
-        parser.add_option('-t', '--tables', type="string", dest='tables', default=None,
-                          help="Comma separated list of tables to use (requires -k to be set)")
-        return parser
+    options = [
+        (['-k', '--keyspace'], {'type': "string", 'dest': "keyspace", 'default': None, 'help': "The keyspace to use [use all keyspaces by default]"}),
+        (['-t', '--tables'], {'type': "string", 'dest': 'tables', 'default': None, 'help': "Comma separated list of tables to use (requires -k to be set)"}),
+    ]
+    descr_text = "Run getsstables to get absolute path of sstables in this node"
+    usage = "usage: ccm node_name getsstables [options] [file]"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -619,23 +514,15 @@ class NodeGetsstablesCmd(Cmd):
 
 class NodeUpdateconfCmd(Cmd):
 
-    def description(self):
-        return "Update the cassandra config files for this node (useful when updating cassandra)"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name updateconf [options] [ new_setting | ...  ], where new_setting should be a string of the form 'compaction_throughput_mb_per_sec: 32'"
-        parser = self._get_default_parser(usage, self.description())
-        parser.add_option('--no-hh', '--no-hinted-handoff', action="store_false",
-                          dest="hinted_handoff", default=True, help="Disable hinted handoff")
-        parser.add_option('--batch-cl', '--batch-commit-log', action="store_true",
-                          dest="cl_batch", default=None, help="Set commit log to batch mode")
-        parser.add_option('--periodic-cl', '--periodic-commit-log', action="store_true",
-                          dest="cl_periodic", default=None, help="Set commit log to periodic mode")
-        parser.add_option('--rt', '--rpc-timeout', action="store", type='int',
-                          dest="rpc_timeout", help="Set rpc timeout")
-        parser.add_option('-y', '--yaml', action="store_true", dest="literal_yaml",
-                          default=False, help="Pass in literal yaml string. Option syntax looks like ccm node_name updateconf -y 'a: [b: [c,d]]'")
-        return parser
+    options = [
+        (['--no-hh', '--no-hinted-handoff'], {'action': "store_false", 'dest': "hinted_handoff", 'default': True, 'help': "Disable hinted handoff"}),
+        (['--batch-cl', '--batch-commit-log'], {'action': "store_true", 'dest': "cl_batch", 'default': None, 'help': "Set commit log to batch mode"}),
+        (['--periodic-cl', '--periodic-commit-log'], {'action': "store_true", 'dest': "cl_periodic", 'default': None, 'help': "Set commit log to periodic mode"}),
+        (['--rt', '--rpc-timeout'], {'action': "store", 'type': 'int', 'dest': "rpc_timeout", 'help': "Set rpc timeout"}),
+        (['-y', '--yaml'], {'action': "store_true", 'dest': "literal_yaml", 'default': False, 'help': "Pass in literal yaml string. Option syntax looks like ccm node_name updateconf -y 'a: [b: [c,d]]'"}),
+    ]
+    descr_text = "Update the cassandra config files for this node (useful when updating cassandra)"
+    usage = "usage: ccm node_name updateconf [options] [ new_setting | ...  ], where new_setting should be a string of the form 'compaction_throughput_mb_per_sec: 32'"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -670,14 +557,11 @@ class NodeUpdateconfCmd(Cmd):
 
 class NodeUpdatedseconfCmd(Cmd):
 
-    def description(self):
-        return "Update the dse config files for this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name updatedseconf [options] [ new_setting | ...  ], where new setting should be a string of the form 'max_solr_concurrency_per_core: 2'; nested options can be separated with a period like 'cql_slow_log_options.enabled: true'"
-        parser = self._get_default_parser(usage, self.description())
-        parser.add_option('-y', '--yaml', action="store_true", dest="literal_yaml", default=False, help="Pass in literal yaml string. Option syntax looks like ccm node_name updatedseconf -y 'a: [b: [c,d]]'")
-        return parser
+    options = [
+        (['-y', '--yaml'], {'action': "store_true", 'dest': "literal_yaml", 'default': False, 'help': "Pass in literal yaml string. Option syntax looks like ccm node_name updatedseconf -y 'a: [b: [c,d]]'"}),
+    ]
+    descr_text = "Update the dse config files for this node"
+    usage = "usage: ccm node_name updatedseconf [options] [ new_setting | ...  ], where new setting should be a string of the form 'max_solr_concurrency_per_core: 2'; nested options can be separated with a period like 'cql_slow_log_options.enabled: true'"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -700,15 +584,11 @@ class NodeUpdatedseconfCmd(Cmd):
 
 class NodeUpdatelog4jCmd(Cmd):
 
-    def description(self):
-        return "Update the Cassandra log4j-server.properties configuration file under given node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name updatelog4j -p <log4j config>"
-        parser = self._get_default_parser(usage, self.description())
-        parser.add_option('-p', '--path', type="string", dest="log4jpath",
-                          help="Path to new Cassandra log4j configuration file")
-        return parser
+    options = [
+        (['-p', '--path'], {'type': "string", 'dest': "log4jpath", 'help': "Path to new Cassandra log4j configuration file"}),
+    ]
+    descr_text = "Update the Cassandra log4j-server.properties configuration file under given node"
+    usage = "usage: ccm node_name updatelog4j -p <log4j config>"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -733,13 +613,9 @@ class NodeUpdatelog4jCmd(Cmd):
 
 class NodeStressCmd(Cmd):
 
-    def description(self):
-        return "Run stress on a node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name stress [options] [stress_options]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Run stress on a node"
+    usage = "usage: ccm node_name stress [options] [stress_options]"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -754,13 +630,9 @@ class NodeStressCmd(Cmd):
 
 class NodeShuffleCmd(Cmd):
 
-    def description(self):
-        return "Run shuffle on a node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name shuffle [options] [shuffle_cmds]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Run shuffle on a node"
+    usage = "usage: ccm node_name shuffle [options] [shuffle_cmds]"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -772,17 +644,12 @@ class NodeShuffleCmd(Cmd):
 
 class NodeSetdirCmd(Cmd):
 
-    def description(self):
-        return "Set the cassandra directory to use for the node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name setdir [options]"
-        parser = self._get_default_parser(usage, self.description())
-        parser.add_option('-v', "--version", type="string", dest="version",
-                          help="Download and use provided cassandra or dse version. If version is of the form 'git:<branch name>', then the specified branch will be downloaded from the git repo and compiled. (takes precedence over --install-dir)", default=None)
-        parser.add_option("--install-dir", type="string", dest="install_dir",
-                          help="Path to the cassandra or dse directory to use [default %default]", default="./")
-        return parser
+    options = [
+        (['-v', "--version"], {'type': "string", 'dest': "version", 'help': "Download and use provided cassandra or dse version. If version is of the form 'git:<branch name>', then the specified branch will be downloaded from the git repo and compiled. (takes precedence over --install-dir)", 'default': None}),
+        (["--install-dir"], {'type': "string", 'dest': "install_dir", 'help': "Path to the cassandra or dse directory to use [default %default]", 'default': "./"}),
+    ]
+    descr_text = "Set the cassandra directory to use for the node"
+    usage = "usage: ccm node_name setdir [options]"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -797,13 +664,8 @@ class NodeSetdirCmd(Cmd):
 
 class NodeSetworkloadCmd(Cmd):
 
-    def description(self):
-        return "Sets the workloads for a DSE node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name setworkload [cassandra|solr|hadoop|spark|dsefs|cfs|graph],..."
-        parser = self._get_default_parser(usage, self.description())
-        return parser
+    descr_text = "Sets the workloads for a DSE node"
+    usage = "usage: ccm node_name setworkload [cassandra|solr|hadoop|spark|dsefs|cfs|graph],..."
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -824,13 +686,9 @@ class NodeSetworkloadCmd(Cmd):
 
 class NodeDseCmd(Cmd):
 
-    def description(self):
-        return "Launch a dse client application connected to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name dse [dse_options]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Launch a dse client application connected to this node"
+    usage = "usage: ccm node_name dse [dse_options]"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -842,13 +700,9 @@ class NodeDseCmd(Cmd):
 
 class NodeHadoopCmd(Cmd):
 
-    def description(self):
-        return "Launch a hadoop session connected to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name hadoop [options] [hadoop_options]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Launch a hadoop session connected to this node"
+    usage = "usage: ccm node_name hadoop [options] [hadoop_options]"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -860,13 +714,9 @@ class NodeHadoopCmd(Cmd):
 
 class NodeHiveCmd(Cmd):
 
-    def description(self):
-        return "Launch a hive session connected to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name hive [options] [hive_options]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Launch a hive session connected to this node"
+    usage = "usage: ccm node_name hive [options] [hive_options]"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -878,13 +728,9 @@ class NodeHiveCmd(Cmd):
 
 class NodePigCmd(Cmd):
 
-    def description(self):
-        return "Launch a pig session connected to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name pig [options] [pig_options]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Launch a pig session connected to this node"
+    usage = "usage: ccm node_name pig [options] [pig_options]"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -896,13 +742,9 @@ class NodePigCmd(Cmd):
 
 class NodeSqoopCmd(Cmd):
 
-    def description(self):
-        return "Launch a sqoop session connected to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name sqoop [options] [sqoop_options]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Launch a sqoop session connected to this node"
+    usage = "usage: ccm node_name sqoop [options] [sqoop_options]"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -914,13 +756,9 @@ class NodeSqoopCmd(Cmd):
 
 class NodeSparkCmd(Cmd):
 
-    def description(self):
-        return "Launch a spark session connected to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name spark [options] [spark_options]"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Launch a spark session connected to this node"
+    usage = "usage: ccm node_name spark [options] [spark_options]"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -932,13 +770,8 @@ class NodeSparkCmd(Cmd):
 
 class NodePauseCmd(Cmd):
 
-    def description(self):
-        return "Send a SIGSTOP to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name pause"
-        parser = self._get_default_parser(usage, self.description())
-        return parser
+    descr_text = "Send a SIGSTOP to this node"
+    usage = "usage: ccm node_name pause"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -949,13 +782,8 @@ class NodePauseCmd(Cmd):
 
 class NodeResumeCmd(Cmd):
 
-    def description(self):
-        return "Send a SIGCONT to this node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name resume"
-        parser = self._get_default_parser(usage, self.description())
-        return parser
+    descr_text = "Send a SIGCONT to this node"
+    usage = "usage: ccm node_name resume"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -966,12 +794,8 @@ class NodeResumeCmd(Cmd):
 
 class NodeJconsoleCmd(Cmd):
 
-    def description(self):
-        return "Opens jconsole client and connect to running node"
-
-    def get_parser(self):
-        usage = "usage: ccm node_name jconsole"
-        return self._get_default_parser(usage, self.description())
+    descr_text = "Opens jconsole client and connect to running node"
+    usage = "usage: ccm node_name jconsole"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -987,13 +811,8 @@ class NodeJconsoleCmd(Cmd):
 
 class NodeVersionfrombuildCmd(Cmd):
 
-    def description(self):
-        return "Print the node's version as grepped from build.xml. Can be used when the node isn't running."
-
-    def get_parser(self):
-        usage = "usage: ccm node_name versionfrombuild"
-        parser = self._get_default_parser(usage, self.description())
-        return parser
+    descr_text = "Print the node's version as grepped from build.xml. Can be used when the node isn't running."
+    usage = "usage: ccm node_name versionfrombuild"
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)
@@ -1004,13 +823,9 @@ class NodeVersionfrombuildCmd(Cmd):
 
 class NodeBytemanCmd(Cmd):
 
-    def description(self):
-        return "Invoke byteman-submit "
-
-    def get_parser(self):
-        usage = "usage: ccm node_name byteman-submit"
-        parser = self._get_default_parser(usage, self.description(), ignore_unknown_options=True)
-        return parser
+    descr_text = "Invoke byteman-submit "
+    usage = "usage: ccm node_name byteman-submit"
+    ignore_unknown_options = True
 
     def validate(self, parser, options, args):
         Cmd.validate(self, parser, options, args, node_name=True, load_cluster=True)

--- a/ccmlib/cmds/node_cmds.py
+++ b/ccmlib/cmds/node_cmds.py
@@ -104,7 +104,7 @@ class NodeShowlogCmd(Cmd):
 
 class NodeSetlogCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-c', '--class'], {'type': "string", 'dest': "class_name", 'default': None, 'help': "Optional java class/package. Logging will be set for only this class/package if set"}),
     ]
     descr_text = "Set node name log level (INFO, DEBUG, ...) with/without Java class - require a node restart"
@@ -134,7 +134,7 @@ class NodeSetlogCmd(Cmd):
 
 class NodeClearCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-a', '--all'], {'action': "store_true", 'dest': "all", 'help': "Also clear the saved cache and node log files", 'default': False}),
     ]
     descr_text = "Clear the node data & logs (and stop the node)"
@@ -150,7 +150,7 @@ class NodeClearCmd(Cmd):
 
 class NodeStartCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-v', '--verbose'], {'action': "store_true", 'dest': "verbose", 'help': "Print standard output of cassandra process", 'default': False}),
         (['--no-wait'], {'action': "store_true", 'dest': "no_wait", 'help': "Do not wait for cassandra node to be ready", 'default': False}),
         (['--wait-other-notice'], {'action': "store_true", 'dest': "deprecate", 'help': "DEPRECATED/IGNORED: Use '--skip-wait-other-notice' instead. This is now on by default.", 'default': False}),
@@ -189,7 +189,7 @@ class NodeStartCmd(Cmd):
 
 class NodeStopCmd(Cmd):
 
-    options = [
+    options_list = [
         (['--no-wait'], {'action': "store_true", 'dest': "no_wait", 'help': "Do not wait for the node to be stopped", 'default': False}),
         (['-g', '--gently'], {'action': "store_const", 'dest': "signal_event", 'help': "Shut down gently (default)", 'const': signal.SIGTERM, 'default': signal.SIGTERM}),
         (['--hang-up'], {'action': "store_const", 'dest': "signal_event", 'help': "Shut down via hang up (kill -1)", 'const': common.get_default_signals()['1']}),
@@ -285,7 +285,7 @@ class NodeVersionCmd(_NodeToolCmd):
 
 class NodeDecommissionCmd(_NodeToolCmd):
     usage = "usage: ccm node_name decommission [options]"
-    options = [
+    options_list = [
         (['--force'], {'action': "store_true", 'dest': "force", 'help': "Force decommission of this node even when it reduces the number of replicas to below configured RF.  Note: This is only relevant for C* 3.12+.", 'default': False}),
     ]
     nodetool_cmd = 'decommission'
@@ -321,7 +321,7 @@ class NodeDsetoolCmd(_DseToolCmd):
 
 class NodeCliCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-x', '--exec'], {'type': "string", 'dest': "cmds", 'default': None, 'help': "Execute the specified commands and exit"}),
         (['-v', '--verbose'], {'action': "store_true", 'dest': "verbose", 'help': "With --exec, show cli output after completion", 'default': False}),
     ]
@@ -344,7 +344,7 @@ class NodeCliCmd(Cmd):
 
 class NodeCqlshCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-x', '--exec'], {'type': "string", 'dest': "cmds", 'default': None, 'help': "Execute the specified commands and exit"}),
         (['-v', '--verbose'], {'action': "store_true", 'dest': "verbose", 'help': "With --exec, show cli output after completion", 'default': False}),
     ]
@@ -404,7 +404,7 @@ class NodeVerifyCmd(Cmd):
 
 class NodeJsonCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-k', '--keyspace'], {'type': "string", 'dest': "keyspace", 'default': None, 'help': "The keyspace to use [use all keyspaces by default]"}),
         (['-c', '--column-families'], {'type': "string", 'dest': "cfs", 'default': None, 'help': "Comma separated list of column families to use (requires -k to be set)"}),
         (['--key'], {'type': "string", 'action': "append", 'dest': "keys", 'default': None, 'help': "The key to include (you may specify multiple --key)"}),
@@ -446,7 +446,7 @@ class NodeJsonCmd(Cmd):
 
 class NodeSstablesplitCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-k', '--keyspace'], {'type': "string", 'dest': "keyspace", 'default': None, 'help': "The keyspace to use [use all keyspaces by default]"}),
         (['-c', '--column-families'], {'type': "string", 'dest': 'cfs', 'default': None, 'help': "Comma separated list of column families to use (requires -k to be set)"}),
         (['-s', '--size'], {'type': 'int', 'dest': "size", 'default': None, 'help': "Maximum size in MB for the output sstables (default: 50 MB)"}),
@@ -482,7 +482,7 @@ class NodeSstablesplitCmd(Cmd):
 
 class NodeGetsstablesCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-k', '--keyspace'], {'type': "string", 'dest': "keyspace", 'default': None, 'help': "The keyspace to use [use all keyspaces by default]"}),
         (['-t', '--tables'], {'type': "string", 'dest': 'tables', 'default': None, 'help': "Comma separated list of tables to use (requires -k to be set)"}),
     ]
@@ -514,7 +514,7 @@ class NodeGetsstablesCmd(Cmd):
 
 class NodeUpdateconfCmd(Cmd):
 
-    options = [
+    options_list = [
         (['--no-hh', '--no-hinted-handoff'], {'action': "store_false", 'dest': "hinted_handoff", 'default': True, 'help': "Disable hinted handoff"}),
         (['--batch-cl', '--batch-commit-log'], {'action': "store_true", 'dest': "cl_batch", 'default': None, 'help': "Set commit log to batch mode"}),
         (['--periodic-cl', '--periodic-commit-log'], {'action': "store_true", 'dest': "cl_periodic", 'default': None, 'help': "Set commit log to periodic mode"}),
@@ -557,7 +557,7 @@ class NodeUpdateconfCmd(Cmd):
 
 class NodeUpdatedseconfCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-y', '--yaml'], {'action': "store_true", 'dest': "literal_yaml", 'default': False, 'help': "Pass in literal yaml string. Option syntax looks like ccm node_name updatedseconf -y 'a: [b: [c,d]]'"}),
     ]
     descr_text = "Update the dse config files for this node"
@@ -584,7 +584,7 @@ class NodeUpdatedseconfCmd(Cmd):
 
 class NodeUpdatelog4jCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-p', '--path'], {'type': "string", 'dest': "log4jpath", 'help': "Path to new Cassandra log4j configuration file"}),
     ]
     descr_text = "Update the Cassandra log4j-server.properties configuration file under given node"
@@ -644,7 +644,7 @@ class NodeShuffleCmd(Cmd):
 
 class NodeSetdirCmd(Cmd):
 
-    options = [
+    options_list = [
         (['-v', "--version"], {'type': "string", 'dest': "version", 'help': "Download and use provided cassandra or dse version. If version is of the form 'git:<branch name>', then the specified branch will be downloaded from the git repo and compiled. (takes precedence over --install-dir)", 'default': None}),
         (["--install-dir"], {'type': "string", 'dest': "install_dir", 'help': "Path to the cassandra or dse directory to use [default %default]", 'default': "./"}),
     ]

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -11,6 +11,7 @@ import os
 import platform
 import re
 import shutil
+import signal
 import socket
 import stat
 import subprocess
@@ -78,10 +79,12 @@ class ArgumentError(CCMError):
 class UnavailableSocketError(CCMError):
     pass
 
+
 class TimeoutError(Exception):
 
     def __init__(self, data):
         Exception.__init__(self, str(data))
+
 
 class LogPatternToVersion(object):
 
@@ -742,3 +745,13 @@ def wait_for_any_log(nodes, pattern, timeout, filename='system.log'):
 
     raise TimeoutError(time.strftime("%d %b %Y %H:%M:%S", time.gmtime()) +
                        " Unable to find: " + repr(pattern) + " in any node log within " + str(timeout) + "s")
+
+
+def get_default_signals():
+    if is_win():
+        # Fill the dictionary with SIGTERM as the cluster is killed forcefully
+        # on Windows regardless of assigned signal (TASKKILL is used)
+        default_signal_events = {'1': signal.SIGTERM, '9': signal.SIGTERM}
+    else:
+        default_signal_events = {'1': signal.SIGHUP, '9': signal.SIGKILL}
+    return default_signal_events


### PR DESCRIPTION
While looking into #258 (use of `argparse` instead of `optparse`\*), I noticed that:

- some of the `Cmd` subclasses had separate fields for `usage` and `descr_text`, but others didn't. So I refactored all `Cmd` subclasses to have them. 
- having the subcommand options in an iterable form would be very convenient for use with `argparse`'s subcommand support. Hence, I pulled out the options to a new `options` field in these classes. 

This left much of the `get_parser()` and `description()` methods repetitive. By moving `ignore_unknown_options` to a field as well, I could eliminate *all* definitions of `get_parser` and `description` in favour of methods in the parent `Cmd` class.

By renaming the `cluster_cmds()` and `node_cmds()` functions, I could also do some DRY refactoring in the main `ccm` script, so there's that as well.

Finally, I added some empty lines here and there to stop `flake8` complaining about PEP8 guidelines (2 blank lines after class/function definitions).

Thoughts?

---
\*  You can see [the WIP state of that here](https://github.com/pcmanus/ccm/compare/master...murukeshm:argparse?expand=1).