### PR TITLE
removed nonexistent yaml key

### DIFF
--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -64,12 +64,6 @@ class DseNode(Node):
         if 'solr' in self.workloads:
             self.__generate_server_xml()
         if 'graph' in self.workloads:
-            conf_file = os.path.join(self.get_path(), 'resources', 'dse', 'conf', 'dse.yaml')
-            with open(conf_file, 'r') as f:
-                data = yaml.load(f)
-            graph_options = data['graph']
-            graph_options['gremlin_server']['host'] = self.ip_addr
-            self.set_dse_configuration_options({'graph': graph_options})
             self.__update_gremlin_config_yaml()
         if 'dsefs' in self.workloads:
             dsefs_options = {'dsefs_options': {'enabled': True,


### PR DESCRIPTION
before:
```
ccm create test --install-dir=/Users/xianteng/bdp/
ccm populate -n 1
ccm setworkload graph
Traceback (most recent call last):
  File "/Users/xianteng/ctool-env/bin/ccm", line 90, in <module>
    cmd.run()
  File "/Users/xianteng/ctool-env/lib/python2.7/site-packages/ccmlib/cmds/cluster_cmds.py", line 855, in run
    node.set_workloads(workloads=self.workloads)
  File "/Users/xianteng/ctool-env/lib/python2.7/site-packages/ccmlib/dse_node.py", line 71, in set_workloads
    graph_options['gremlin_server']['host'] = self.ip_addr
TypeError: 'NoneType' object does not support item assignment
```
after, things work fine

it doesn't look like there was ever a `graph.gremlin_server.host` in dse.yaml