### PR TITLE
Add the ability to remotely execute CCM commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.4.5"
   - "3.5.2"
 install:
-  - pip install pylint six pyyaml
+  - pip install pylint six pyyaml paramiko
 script:
   - pylint --py3k --disable=W1633,W1648 ccmlib
   - pylint --disable=all --enable=E,F ccmlib

--- a/ccm
+++ b/ccm
@@ -6,6 +6,7 @@ from six import print_
 
 from ccmlib import common
 from ccmlib.cmds import command, cluster_cmds, node_cmds
+from ccmlib.remote import PARAMIKO_IS_AVAILABLE, get_remote_usage, get_remote_options, execute_ccm_remotely
 
 
 def get_command(kind, cmd):
@@ -30,8 +31,14 @@ def print_subcommand_usage(kind):
 
 def print_global_usage():
     print_("Usage:")
-    print_("  ccm <cluster_cmd> [options]")
-    print_("  ccm <node_name> <node_cmd> [options]")
+    remote_options = ""
+    if PARAMIKO_IS_AVAILABLE:
+        remote_options = " [remote_options]"
+    print_("  ccm" + remote_options + " <cluster_cmd> [options]")
+    print_("  ccm" + remote_options + " <node_name> <node_cmd> [options]")
+    if PARAMIKO_IS_AVAILABLE:
+        print_("")
+        print_(get_remote_usage())
     print_("")
     print_("Where <cluster_cmd> is one of")
     print_subcommand_usage('cluster')
@@ -63,6 +70,14 @@ if arg1 == 'show-node-cmds':
     for cmd_name in node_cmds.commands():
         print_(cmd_name)
     exit(1)
+
+# Attempt a remote execution (only occurs if remote options are valid and ssh_host is set)
+# NOTE: An execption may be thrown if there are errors
+if PARAMIKO_IS_AVAILABLE:
+    remote_options, ccm_args = get_remote_options();
+    if not remote_options is None and not remote_options.ssh_host is None:
+        ouput, exit_status = execute_ccm_remotely(remote_options, ccm_args)
+        sys.exit(exit_status)
 
 if arg1 in cluster_cmds.commands():
     kind = 'cluster'

--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -1,6 +1,7 @@
 
 from __future__ import absolute_import
 
+import os
 import sys
 from optparse import BadOptionError, Option, OptionParser
 import re
@@ -9,6 +10,7 @@ from six import print_
 
 from ccmlib import common
 from ccmlib.cluster_factory import ClusterFactory
+from ccmlib.remote import PARAMIKO_IS_AVAILABLE, get_remote_usage
 
 
 # This is fairly fragile, but handy for now
@@ -51,6 +53,11 @@ class Cmd(object):
     def get_parser(self):
         if self.usage == "":
             pass
+        if PARAMIKO_IS_AVAILABLE:
+            self.usage = self.usage.replace("usage: ccm",
+                                            "usage: ccm [remote_options]") + \
+                         os.linesep + os.linesep + \
+                         get_remote_usage()
         parser = self._get_default_parser(self.usage, self.description(), self.ignore_unknown_options)
         for args, kwargs in self.options_list:
             parser.add_option(*args, **kwargs)

--- a/ccmlib/remote.py
+++ b/ccmlib/remote.py
@@ -1,0 +1,501 @@
+#
+# Remote execution helper functionality for executing CCM commands on a remote
+# machine with CCM installed
+#
+
+from __future__ import absolute_import
+
+import argparse
+import logging
+import os
+import re
+import select
+import stat
+import sys
+import tempfile
+
+# Paramiko is an optional library as SSH is optional for CCM
+PARAMIKO_IS_AVAILABLE = False
+try:
+    import paramiko
+    PARAMIKO_IS_AVAILABLE = True
+except ImportError:
+    pass
+
+
+def get_remote_usage():
+    """
+    Get the usage for the remote exectuion options
+
+    :return Usage for the remote execution options
+    """
+    return RemoteOptionsParser().usage()
+
+
+def get_remote_options():
+    """
+    Parse the command line arguments and split out the CCM arguments and the remote options
+
+    :return: A tuple defining the arguments parsed and actions to take
+               * remote_options - Remote options only
+               * ccm_args       - CCM arguments only
+    :raises Exception if private key is not a file
+    """
+    return RemoteOptionsParser().parse_known_options()
+
+
+def execute_ccm_remotely(remote_options, ccm_args):
+    """
+    Execute CCM operation(s) remotely
+
+    :return A tuple defining the execution of the command
+              * output      - The output of the execution if the output was not displayed
+              * exit_status - The exit status of remotely executed script
+    :raises Exception if invalid options are passed for `--dse-credentials`, `--ssl`, or
+                      `--node-ssl` when initiating a remote execution; also if
+                      error occured during ssh connection
+    """
+    if not PARAMIKO_IS_AVAILABLE:
+        logging.warn("Paramiko is not Availble: Skipping remote execution of CCM command")
+        return None, None
+
+    # Create the SSH client
+    ssh_client = SSHClient(remote_options.ssh_host, remote_options.ssh_port,
+                           remote_options.ssh_username, remote_options.ssh_password,
+                           remote_options.ssh_private_key)
+
+    # Handle CCM arguments that require SFTP
+    for index, argument in enumerate(ccm_args):
+        # Determine if DSE credentials argument is being used
+        if "--dse-credentials" in argument:
+            # Get the filename being used for the DSE credentials
+            tokens = argument.split("=")
+            credentials_path = os.path.join(os.path.expanduser("~"), ".ccm", ".dse.ini")
+            if len(tokens) == 2:
+                credentials_path = tokens[1]
+
+            # Ensure the credential file exists locally and copy to remote host
+            if not os.path.isfile(credentials_path):
+                raise Exception("DSE Credentials File Does not Exist: %s"
+                                % credentials_path)
+            ssh_client.put(credentials_path, ssh_client.ccm_config_dir)
+
+            # Update the DSE credentials argument
+            ccm_args[index] = "--dse-credentials"
+
+        # Determine if SSL or node SSL path argument is being used
+        if "--ssl" in argument or "--node-ssl" in argument:
+            # Get the directory being used for the path
+            tokens = argument.split("=")
+            if len(tokens) != 2:
+                raise Exception("Path is not Specified: %s" % argument)
+            ssl_path = tokens[1]
+
+            # Ensure the path exists locally and copy to remote host
+            if not os.path.isdir(ssl_path):
+                raise Exception("Path Does not Exist: %s" % ssl_path)
+            remote_ssl_path = ssh_client.temp + os.path.basename(ssl_path)
+            ssh_client.put(ssl_path, remote_ssl_path)
+
+            # Update the argument
+            ccm_args[index] = tokens[0] + "=" + remote_ssl_path
+
+    # Execute the CCM request, return output and exit status
+    return ssh_client.execute_ccm_command(ccm_args)
+
+
+class SSHClient:
+    """
+    SSH client class used to handle SSH operations to the remote host
+    """
+
+    def __init__(self, host, port, username, password, private_key=None):
+        """
+        Create the SSH client
+
+        :param host: Hostname or IP address to connect to
+        :param port: Port number to use for SSH
+        :param username: Username credentials for SSH access
+        :param password: Password credentials for SSH access (or private key passphrase)
+        :param private_key: Private key to bypass clear text password (default: None - Username and
+                            password credentials)
+        """
+        # Reduce the noise from the logger for paramiko
+        logging.getLogger("paramiko").setLevel(logging.WARNING)
+
+        # Establish the SSH connection
+        self.ssh = self.__connect(host, port, username, password, private_key)
+
+        # Gather information about the remote OS
+        information = self.__server_information()
+        self.separator = information[1]
+        self.home = information[0] + self.separator
+        self.temp = information[2] + self.separator
+        self.platform = information[3]
+        self.profile = information[4]
+        self.distribution = information[5]
+
+        # Create the CCM configuration directory variable
+        self.ccm_config_dir = self.home + self.separator + ".ccm" + self.separator
+
+    @staticmethod
+    def __connect(host, port, username, password, private_key):
+        """
+        Establish remote connection
+
+        :param host: Hostname or IP address to connect to
+        :param port: Port number to use for SSH
+        :param username: Username credentials for SSH access
+        :param password: Password credentials for SSH access (or private key passphrase)
+        :param private_key: Private key to bypass clear text password
+        :return: Paramiko SSH client instance if connection was established
+        :raises Exception if connection was unsuccessful
+        """
+        # Initialize the SSH connection
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        if private_key is not None and password is not None:
+            private_key = paramiko.RSAKey.from_private_key_file(private_key, password)
+        elif private_key is not None:
+            private_key = paramiko.RSAKey.from_private_key_file(private_key, password)
+
+        # Establish the SSH connection
+        try:
+            ssh.connect(host, port, username, password, private_key)
+        except Exception as e:
+            raise e
+
+        # Return the established SSH connection
+        return ssh
+
+    def execute(self, command, is_displayed=True, profile=None):
+        """
+        Execute a command on the remote server
+
+        :param command: Command to execute remotely
+        :param is_displayed: True if information should be display; false to return output
+                             (default: true)
+        :param profile: Profile to source (unix like system only should set this)
+                        (default: None)
+        :return: A tuple defining the execution of the command
+                   * output      - The output of the execution if the output was not displayed
+                   * exit_status - The exit status of remotely executed script
+        """
+        # Modify the command for remote execution
+        command = " ".join("'{0}'".format(argument) for argument in command)
+
+        # Execute the command and initialize for reading (close stdin/writes)
+        if not profile is None and not profile is "None":
+            command = "source " + profile + ";" + command
+        stdin, stdout, stderr = self.ssh.exec_command(command)
+        stdin.channel.shutdown_write()
+        stdin.close()
+
+
+        # Print or gather output as is occurs
+        output = None
+        if not is_displayed:
+            output = []
+            output.append(stdout.channel.recv(len(stdout.channel.in_buffer)).decode("utf-8"))
+            output.append(stderr.channel.recv(len(stderr.channel.in_buffer)).decode("utf-8"))
+        channel = stdout.channel
+        while not channel.closed or channel.recv_ready() or channel.recv_stderr_ready():
+            # Ensure the channel was not closed prematurely and all data has been ready
+            is_data_present = False
+            handles = select.select([channel], [], [])
+            for read in handles[0]:
+                # Read stdout and/or stderr if data is present
+                buffer = None
+                if read.recv_ready():
+                    buffer = channel.recv(len(read.in_buffer)).decode("utf-8")
+                    if is_displayed:
+                        sys.stdout.write(buffer)
+                if read.recv_stderr_ready():
+                    buffer = stderr.channel.recv_stderr(len(read.in_stderr_buffer)).decode("utf-8")
+                    if is_displayed:
+                        sys.stderr.write(buffer)
+
+                # Determine if the output should be updated and displayed
+                if buffer is not None:
+                    is_data_present = True
+                    if not is_displayed:
+                        output.append(buffer)
+
+            # Ensure all the data has been read and exit loop if completed
+            if (not is_data_present and channel.exit_status_ready()
+                and not stderr.channel.recv_stderr_ready()
+                and not channel.recv_ready()):
+                # Stop reading and close the channel to stop processing
+                channel.shutdown_read()
+                channel.close()
+                break
+
+        # Close file handles for stdout and stderr
+        stdout.close()
+        stderr.close()
+
+        # Process the output (if available)
+        if output is not None:
+            output = "".join(output)
+
+        # Return the output from the executed command
+        return output, channel.recv_exit_status()
+
+    def execute_ccm_command(self, ccm_args, is_displayed=True):
+        """
+        Execute a CCM command on the remote server
+
+        :param ccm_args: CCM arguments to execute remotely
+        :param is_displayed: True if information should be display; false to return output
+                             (default: true)
+        :return: A tuple defining the execution of the command
+                   * output      - The output of the execution if the output was not displayed
+                   * exit_status - The exit status of remotely executed script
+        """
+        return self.execute(["ccm"] + ccm_args, profile=self.profile)
+
+    def execute_python_script(self, script):
+        """
+        Execute a python script of the remote server
+
+        :param script: Inline script to convert to a file and execute remotely
+        :return: The output of the script execution
+        """
+        # Create the local file to copy to remote
+        file_handle, filename = tempfile.mkstemp()
+        temp_file = os.fdopen(file_handle, "wt")
+        temp_file.write(script)
+        temp_file.close()
+
+        # Put the file into the remote user directory
+        self.put(filename, "python_execute.py")
+        command = ["python", "python_execute.py"]
+
+        # Execute the python script on the remote system, clean up, and return the output
+        output = self.execute(command, False)
+        self.remove("python_execute.py")
+        os.unlink(filename)
+        return output
+
+    def put(self, local_path, remote_path=None):
+        """
+        Copy a file (or directory recursively) to a location on the remote server
+
+        :param local_path: Local path to copy to; can be file or directory
+        :param remote_path: Remote path to copy to (default: None - Copies file or directory to
+                            home directory directory on the remote server)
+        """
+        # Determine if local_path should be put into remote user directory
+        if remote_path is None:
+            remote_path = os.path.basename(local_path)
+
+        ftp = self.ssh.open_sftp()
+        if os.path.isdir(local_path):
+            self.__put_dir(ftp, local_path, remote_path)
+        else:
+            ftp.put(local_path, remote_path)
+        ftp.close()
+
+    def __put_dir(self, ftp, local_path, remote_path=None):
+        """
+        Helper function to perform copy operation to remote server
+
+        :param ftp: SFTP handle to perform copy operation(s)
+        :param local_path: Local path to copy to; can be file or directory
+        :param remote_path: Remote path to copy to (default: None - Copies file or directory to
+                            home directory directory on the remote server)
+        """
+        # Determine if local_path should be put into remote user directory
+        if remote_path is None:
+            remote_path = os.path.basename(local_path)
+        remote_path += self.separator
+
+        # Iterate over the local path and perform copy operations to remote server
+        for current_path, directories, files in os.walk(local_path):
+            # Create the remote directory (if needed)
+            try:
+                ftp.listdir(remote_path)
+            except IOError:
+                ftp.mkdir(remote_path)
+
+            # Copy the files in the current directory to the remote path
+            for filename in files:
+                ftp.put(os.path.join(current_path, filename), remote_path + filename)
+            # Copy the directory in the current directory to the remote path
+            for directory in directories:
+                self.__put_dir(ftp, os.path.join(current_path, directory), remote_path + directory)
+
+    def remove(self, remote_path):
+        """
+        Delete a file or directory recursively on the remote server
+
+        :param remote_path: Remote path to remove
+        """
+        # Based on the remote file stats; remove a file or directory recursively
+        ftp = self.ssh.open_sftp()
+        if stat.S_ISDIR(ftp.stat(remote_path).st_mode):
+            self.__remove_dir(ftp, remote_path)
+        else:
+            ftp.remove(remote_path)
+        ftp.close()
+
+    def __remove_dir(self, ftp, remote_path):
+        """
+        Helper function to perform delete operation on the remote server
+
+        :param ftp: SFTP handle to perform delete operation(s)
+        :param remote_path: Remote path to remove
+        """
+        # Iterate over the remote path and perform remove operations
+        files = ftp.listdir(remote_path)
+        for filename in files:
+            # Attempt to remove the file (if exception then path is directory)
+            path = remote_path + self.separator + filename
+            try:
+                ftp.remove(path)
+            except IOError:
+                self.__remove_dir(ftp, path)
+
+        # Remove the original directory requested
+        ftp.rmdir(remote_path)
+
+    def __server_information(self):
+        """
+        Get information about the remote server:
+            * User's home directory
+            * OS separator
+            * OS temporary directory
+            * Platform information
+            * Profile to source (Available only on unix-like platforms (including Mac OS))
+            * Platform distribution ((Available only on unix-like platforms)
+        :return: Remote executed script with the above information (line by line in order)
+        """
+        return self.execute_python_script("""import os
+import platform
+import sys
+import tempfile
+
+# Standard system information
+print(os.path.expanduser("~"))
+print(os.sep)
+print(tempfile.gettempdir())
+print(platform.system())
+
+# Determine the profile for unix like systems
+if sys.platform == "darwin" or sys.platform == "linux" or sys.platform == "linux2":
+    if os.path.isfile(".profile"):
+        print(os.path.expanduser("~") + os.sep + ".profile")
+    elif os.path.isfile(".bash_profile"):
+        print(os.path.expanduser("~") + os.sep + ".bash_profile")
+    else:
+        print("None")
+else:
+    print("None")
+
+# Get the disto information for unix like system (excluding Mac OS)
+if sys.platform == "linux" or sys.platform == "linux2":
+    print(platform.linux_distribution())
+else:
+    print("None")
+""")[0].splitlines()
+
+
+class RemoteOptionsParser():
+    """
+    Parser class to facilitate remote execution of CCM operations via command
+    line arguments
+    """
+
+    def __init__(self):
+        """
+        Create the parser for the remote CCM operations allowed
+        """
+        self.parser = argparse.ArgumentParser(description="Remote",
+                                              add_help=False)
+
+        # Add the SSH arguments for the remote parser
+        self.parser.add_argument(
+            "--ssh-host",
+            default=None,
+            type=str,
+            help="Hostname or IP address to use for SSH connection"
+        )
+        self.parser.add_argument(
+            "--ssh-port",
+            default=22,
+            type=self.port,
+            help="Port to use for SSH connection"
+        )
+        self.parser.add_argument(
+            "--ssh-username",
+            default=None,
+            type=str,
+            help="Username to use for username/password or public key authentication"
+        )
+        self.parser.add_argument(
+            "--ssh-password",
+            default=None,
+            type=str,
+            help="Password to use for username/password or private key passphrase using public "
+                 "key authentication"
+        )
+        self.parser.add_argument(
+            "--ssh-private-key",
+            default=None,
+            type=self.ssh_key,
+            help="Private key to use for SSH connection"
+        )
+
+    def parse_known_options(self):
+        """
+        Parse the command line arguments and split out the remote options and CCM arguments
+
+        :return: A tuple defining the arguments parsed and actions to take
+                   * remote_options    - Remote options only
+                   * ccm_args          - CCM arguments only
+        """
+        # Parse the known arguments and return the remote options and CCM arguments
+        remote_options, ccm_args = self.parser.parse_known_args()
+        return remote_options, ccm_args
+
+    @staticmethod
+    def ssh_key(key):
+        """
+        SSH key parser validator (ensure file exists)
+
+        :param key: Filename/Key to validate (ensure exists)
+        :return: The filename/key passed in (if valid)
+        :raises Exception if filename/key is not a valid file
+        """
+        value = str(key)
+        # Ensure the file exists locally
+        if not os.path.isfile(value):
+            raise Exception("File Does not Exist: %s" % key)
+        return value
+
+    @staticmethod
+    def port(port):
+        """
+        Port validator
+
+        :param port: Port to validate (1 - 65535)
+        :return: Port passed in (if valid)
+        :raises ArgumentTypeError if port is not valid
+        """
+        value = int(port)
+        if value <= 0 or value > 65535:
+            raise argparse.ArgumentTypeError("%s must be between [1 - 65535]" % port)
+        return value
+
+    def usage(self):
+        """
+        Get the usage for the remote exectuion options
+
+        :return Usage for the remote execution options
+        """
+        # Retrieve the text for just the arguments
+        usage = self.parser.format_help().split("optional arguments:")[1]
+
+        # Remove any blank lines and return
+        return "Remote Options:" + os.linesep + \
+               os.linesep.join([s for s in usage.splitlines() if s])

--- a/misc/Vagrantfile
+++ b/misc/Vagrantfile
@@ -1,0 +1,110 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Configure defaults and/or allow to be overridden
+if ENV.has_key?("CCM")
+  CCM = ENV["CCM"]
+else
+  CCM = "master"
+end
+if ENV.has_key?("QUIET")
+  QUIET = ENV["QUIET"]
+else
+  QUIET = "true"
+end
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+# Inline provision script
+CCM_PROVISION_SCRIPT = <<EOF
+#!/bin/bash
+
+# Retrieve the version variables from the provisioning arguments
+CCM_VERSION=${1}
+
+echo CCM [${CCM_VERSION}]
+
+# Determine if output should be suppressed
+REDIRECT=/dev/null
+if [ "${2}" == "false" ]
+then
+  REDIRECT=/dev/stdout
+fi
+
+#Install package updates
+echo Installing System Packages ...
+apt-get install -qq python-software-properties > ${REDIRECT} 2>&1
+# Add JDK repository and update packages
+add-apt-repository ppa:webupd8team/java -y > ${REDIRECT} 2>&1
+apt-get update -y > ${REDIRECT} 2>&1
+apt-get upgrade -y > ${REDIRECT} 2>&1
+
+# Auto accept the the Java license aggreement
+echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
+echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
+
+# Install the packages
+apt-get install -qq ant git libxml2-dev libxslt1-dev libyaml-dev maven oracle-java8-installer \\
+                    oracle-java8-unlimited-jce-policy python2.7-dev python-pip vim-gtk \\
+                    zlib1g-dev > ${REDIRECT} 2>&1
+
+# Upgrade pip
+pip install --upgrade pip > ${REDIRECT} 2>&1
+
+# Install CCM and its dependencies
+echo Installing CCM ...
+pip install git+https://github.com/pcmanus/ccm.git@${CCM_VERSION} > ${REDIRECT} 2>&1
+EOF
+
+##
+# Configure a 6 node Cassandra Cluster Manager (CCM) Virtual Machine (VM) with
+# the following settings:
+#
+#   - 4GB of RAM
+#   - 32MB of Video RAM
+#   - 4 cores (CPUs)
+#   - Hostname: ccm-cluster
+#   - Username: vagrant
+#   - Password: vagrant
+#   - 6 Network Interfaces Cards (NICs)
+#     - Node 1: 192.168.33.11
+#     - Node 2: 192.168.33.12
+#     - Node 3: 192.168.33.13
+#     - Node 4: 192.168.33.14
+#     - Node 5: 192.168.33.15
+#     - Node 6: 192.168.33.16
+##
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Create Ubuntu 16.04 LTS VM
+  config.vm.box = "bento/ubuntu-16.04"
+
+  # Define the hostname and IP addresses (6 node cluster)
+  config.vm.define "ccm-cluster" do |ccm_cluster|
+    ccm_cluster.vm.hostname = "ccm-cluster"
+    ccm_cluster.vm.network "private_network", ip: "192.168.33.11"
+    ccm_cluster.vm.network "private_network", ip: "192.168.33.12"
+    ccm_cluster.vm.network "private_network", ip: "192.168.33.13"
+    ccm_cluster.vm.network "private_network", ip: "192.168.33.14"
+    ccm_cluster.vm.network "private_network", ip: "192.168.33.15"
+    ccm_cluster.vm.network "private_network", ip: "192.168.33.16"
+  end
+
+  # Prepare/Provision the VM
+  config.vm.provision :shell do |root_provision|
+    root_provision.privileged = true
+    root_provision.inline = CCM_PROVISION_SCRIPT
+    root_provision.args = [ "#{CCM}", "#{QUIET}" ]
+  end
+
+  # VM parameters for the CCM cluster
+  config.vm.provider :virtualbox do |provider|
+    provider.name = "ccm-cluster"
+    provider.customize ["modifyvm", :id, "--groups", "/Testing"]
+    provider.customize ["modifyvm", :id, "--memory", "4096"]
+    provider.customize ["modifyvm", :id, "--vram", "32"]
+    provider.customize ["modifyvm", :id, "--cpus", "4"]
+    provider.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    provider.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+  end
+end


### PR DESCRIPTION
* Handles `--dse-credentials`, `--node-ssl`, and `-ssl`
  * Files will be copied from local to remote before execution
* Updated documentation to reflect new remote options

This update adds the ability to specify a remote host to execute CCM
commands on. The remote machine must be pre-configured to accept SSH
connections, sequential IP addresses for simple node creation, and a
installed instance of CCM; see misc/Vagrantfile for simplified guest
installation.

__Note__: This update is optional and requires that `paramiko` is
          installed in order to function.