### PR TITLE
Use dse.yaml resource_manager_options in newer DSE versions for spark

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -280,11 +280,13 @@ def make_cassandra_env(install_dir, node_path, update_conf=True):
 
 
 def make_dse_env(install_dir, node_path, node_ip):
+    version = get_version_from_build(node_path=node_path)
     env = os.environ.copy()
     env['MAX_HEAP_SIZE'] = os.environ.get('CCM_MAX_HEAP_SIZE', '500M')
     env['HEAP_NEWSIZE'] = os.environ.get('CCM_HEAP_NEWSIZE', '50M')
-    env['SPARK_WORKER_MEMORY'] = os.environ.get('SPARK_WORKER_MEMORY', '1024M')
-    env['SPARK_WORKER_CORES'] = os.environ.get('SPARK_WORKER_CORES', '2')
+    if version < '6.0':
+        env['SPARK_WORKER_MEMORY'] = os.environ.get('SPARK_WORKER_MEMORY', '1024M')
+        env['SPARK_WORKER_CORES'] = os.environ.get('SPARK_WORKER_CORES', '2')
     env['DSE_HOME'] = os.path.join(install_dir)
     env['DSE_CONF'] = os.path.join(node_path, 'resources', 'dse', 'conf')
     env['CASSANDRA_HOME'] = os.path.join(install_dir, 'resources', 'cassandra')
@@ -305,7 +307,7 @@ def make_dse_env(install_dir, node_path, node_ip):
     env['DSE_LOG_ROOT'] = os.path.join(node_path, 'logs', 'dse')
     env['CASSANDRA_LOG_DIR'] = os.path.join(node_path, 'logs')
     env['SPARK_LOCAL_IP'] = '' + node_ip
-    if get_version_from_build(node_path=node_path) >= '5.0':
+    if version >= '5.0':
         env['HADOOP1_CONF_DIR'] = os.path.join(node_path, 'resources', 'hadoop', 'conf')
         env['HADOOP2_CONF_DIR'] = os.path.join(node_path, 'resources', 'hadoop2-client', 'conf')
     else:

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -71,11 +71,14 @@ class DseNode(Node):
                                                'data_directories': [{'dir': os.path.join(self.get_path(), 'dsefs', 'data')}]}}
             self.set_dse_configuration_options(dsefs_options)
         if 'spark' in self.workloads:
-            dsefs_options = {'dsefs_options': {'enabled': False,
-                                               'work_dir': os.path.join(self.get_path(), 'dsefs'),
-                                               'data_directories': [
-                                                   {'dir': os.path.join(self.get_path(), 'dsefs', 'data')}]}}
-            self.set_dse_configuration_options(dsefs_options)
+            dsefs_enabled = 'dsefs' in self.workloads
+            dse_options = {'dsefs_options': {'enabled': dsefs_enabled,
+                                             'work_dir': os.path.join(self.get_path(), 'dsefs'),
+                                             'data_directories': [{'dir': os.path.join(self.get_path(), 'dsefs', 'data')}]}}
+            if self.cluster.version() >= '6.0':
+                dse_options['resource_manager_options'] = {'worker_options' : {'memory_total': '1g', 'cores_total': 2}}
+
+            self.set_dse_configuration_options(dse_options)
             self._update_spark_env()
 
     def set_dse_configuration_options(self, values=None):


### PR DESCRIPTION
Newer versions of DSE allow configuring spark resource settings via dse.yaml in the following manner:

```yaml
resource_manager_options:
  worker_options:
    memory_total: 0.1
    cores_total: 0.2
```

This sets the resources used by spark as a ratio of system resources instead of fixed.  I chose 0.1 memory and 0.2 cores to get close to the previous config (1024M / 2 cores) on a modern mac book pro (1.6GB ram, 2 cores).  The environment variables `SPARK_WORKER_MEMORY` and `SPARK_WORKER_CORES` are still used for older versions.