### PR TITLE
Store cassandra_version with config to prevent repeated parsing

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -284,8 +284,8 @@ class Cluster(object):
             self._update_config()
         return self
 
-    def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None):
-        return Node(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables)
+    def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None, cassandra_version=None):
+        return Node(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables, cassandra_version=cassandra_version)
 
     def balanced_tokens(self, node_count):
         if self.cassandra_version() >= '1.2' and (not self.partitioner or 'Murmur3' in self.partitioner):
@@ -603,7 +603,9 @@ class Cluster(object):
             'log_level': self.__log_level,
             'use_vnodes': self.use_vnodes,
             'datadirs': self.data_dir_count,
-            'environment_variables': self._environment_variables
+            'environment_variables': self._environment_variables,
+            'version': str(self.version()),
+            'cassandra_version': str(self.cassandra_version())
         }
         extension.append_to_cluster_config(self, config_map)
         with open(filename, 'w') as f:

--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -10,6 +10,7 @@ from ccmlib.cluster import Cluster
 from ccmlib.dse_cluster import DseCluster
 from ccmlib.node import Node
 
+from distutils.version import LooseVersion  #pylint: disable=import-error, no-name-in-module
 
 class ClusterFactory():
 
@@ -28,10 +29,19 @@ class ClusterFactory():
                 install_dir = data['cassandra_dir']
                 repository.validate(install_dir)
 
+            version = None
+            if 'version' in data:
+                # Note: version isn't wrapped in LooseVersion as constructors expect string version and convert later.
+                version = data['version']
+
+            cassandra_version = None
+            if 'cassandra_version' in data:
+                cassandra_version = LooseVersion(data['cassandra_version'])
+
             if common.isDse(install_dir):
-                cluster = DseCluster(path, data['name'], install_dir=install_dir, create_directory=False)
+                cluster = DseCluster(path, data['name'], install_dir=install_dir, create_directory=False, version=version, cassandra_version=cassandra_version)
             else:
-                cluster = Cluster(path, data['name'], install_dir=install_dir, create_directory=False)
+                cluster = Cluster(path, data['name'], install_dir=install_dir, create_directory=False, version=version, cassandra_version=version)
             node_list = data['nodes']
             seed_list = data['seeds']
             if 'partitioner' in data:

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -22,7 +22,7 @@ except ImportError:
 
 class DseCluster(Cluster):
 
-    def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, dse_username=None, dse_password=None, dse_credentials_file=None, opscenter=None, verbose=False):
+    def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, dse_username=None, dse_password=None, dse_credentials_file=None, opscenter=None, verbose=False, cassandra_version=None):
         self.dse_username = None
         self.dse_password = None
         self.load_credentials_from_file(dse_credentials_file)
@@ -32,6 +32,10 @@ class DseCluster(Cluster):
             self.dse_password = dse_password
 
         self.opscenter = opscenter
+        self._cassandra_version = None
+        if cassandra_version:
+            self._cassandra_version = cassandra_version
+
         super(DseCluster, self).__init__(path, name, partitioner, install_dir, create_directory, version, verbose)
 
     def load_from_repository(self, version, verbose):
@@ -62,8 +66,8 @@ class DseCluster(Cluster):
     def hasOpscenter(self):
         return os.path.exists(os.path.join(self.get_path(), 'opscenter'))
 
-    def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None):
-        return DseNode(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables=environment_variables)
+    def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None,cassandra_version=None):
+        return DseNode(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables=environment_variables, cassandra_version=cassandra_version)
 
     def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=True, jvm_args=None, profile_options=None, quiet_start=False, allow_root=False):
         if jvm_args is None:
@@ -78,7 +82,9 @@ class DseCluster(Cluster):
         return not_running
 
     def cassandra_version(self):
-        return common.get_dse_cassandra_version(self.get_install_dir())
+        if self._cassandra_version is None:
+            self._cassandra_version = common.get_dse_cassandra_version(self.get_install_dir())
+        return self._cassandra_version
 
     def set_dse_configuration_options(self, values=None):
         if values is not None:

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -23,9 +23,9 @@ class DseNode(Node):
     Provides interactions to a DSE node.
     """
 
-    def __init__(self, name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None):
-        super(DseNode, self).__init__(name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables=environment_variables)
-        self.get_cassandra_version()
+    def __init__(self, name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None, cassandra_version=None):
+        super(DseNode, self).__init__(name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables=environment_variables, cassandra_version=cassandra_version)
+       
         self._dse_config_options = {}
         if self.cluster.hasOpscenter():
             self._copy_agent()
@@ -50,9 +50,6 @@ class DseNode(Node):
 
     def get_env(self):
         return common.make_dse_env(self.get_install_dir(), self.get_path(), self.ip_addr)
-
-    def get_cassandra_version(self):
-        return common.get_dse_cassandra_version(self.get_install_dir())
 
     def node_setup(self, version, verbose):
         dir, v = repository.setup_dse(version, self.cluster.dse_username, self.cluster.dse_password, verbose=verbose)


### PR DESCRIPTION
Noticed that common.get_version_from_build and
get_dse_cassandra_version were invoked frequently when creating clusters
and using ccm command later (as many as 35 times).
These functions parse files on the file system to extract C* and DSE
versions.  Updated code to now store version and cassandra_version
with cluster and node config.

Also updated get_dse_cassandra_version to use `bin/dse cassandra -v`
instead of looking for cassandra-all.jar and parsing version number from
it.