### PR TITLE
Fix issues with stored version config.

### DIFF
--- a/ccmlib/cluster_factory.py
+++ b/ccmlib/cluster_factory.py
@@ -29,19 +29,14 @@ class ClusterFactory():
                 install_dir = data['cassandra_dir']
                 repository.validate(install_dir)
 
-            version = None
-            if 'version' in data:
-                # Note: version isn't wrapped in LooseVersion as constructors expect string version and convert later.
-                version = data['version']
-
             cassandra_version = None
             if 'cassandra_version' in data:
                 cassandra_version = LooseVersion(data['cassandra_version'])
 
             if common.isDse(install_dir):
-                cluster = DseCluster(path, data['name'], install_dir=install_dir, create_directory=False, version=version, cassandra_version=cassandra_version)
+                cluster = DseCluster(path, data['name'], install_dir=install_dir, create_directory=False, derived_cassandra_version=cassandra_version)
             else:
-                cluster = Cluster(path, data['name'], install_dir=install_dir, create_directory=False, version=version, cassandra_version=version)
+                cluster = Cluster(path, data['name'], install_dir=install_dir, create_directory=False, derived_cassandra_version=cassandra_version)
             node_list = data['nodes']
             seed_list = data['seeds']
             if 'partitioner' in data:

--- a/ccmlib/dse_cluster.py
+++ b/ccmlib/dse_cluster.py
@@ -22,7 +22,7 @@ except ImportError:
 
 class DseCluster(Cluster):
 
-    def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, dse_username=None, dse_password=None, dse_credentials_file=None, opscenter=None, verbose=False, cassandra_version=None):
+    def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, dse_username=None, dse_password=None, dse_credentials_file=None, opscenter=None, verbose=False, derived_cassandra_version=None):
         self.dse_username = None
         self.dse_password = None
         self.load_credentials_from_file(dse_credentials_file)
@@ -33,8 +33,8 @@ class DseCluster(Cluster):
 
         self.opscenter = opscenter
         self._cassandra_version = None
-        if cassandra_version:
-            self._cassandra_version = cassandra_version
+        if derived_cassandra_version:
+            self._cassandra_version = derived_cassandra_version
 
         super(DseCluster, self).__init__(path, name, partitioner, install_dir, create_directory, version, verbose)
 
@@ -66,8 +66,8 @@ class DseCluster(Cluster):
     def hasOpscenter(self):
         return os.path.exists(os.path.join(self.get_path(), 'opscenter'))
 
-    def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None,cassandra_version=None):
-        return DseNode(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables=environment_variables, cassandra_version=cassandra_version)
+    def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None,derived_cassandra_version=None):
+        return DseNode(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables=environment_variables, derived_cassandra_version=derived_cassandra_version)
 
     def start(self, no_wait=False, verbose=False, wait_for_binary_proto=False, wait_other_notice=True, jvm_args=None, profile_options=None, quiet_start=False, allow_root=False):
         if jvm_args is None:

--- a/ccmlib/dse_node.py
+++ b/ccmlib/dse_node.py
@@ -23,8 +23,8 @@ class DseNode(Node):
     Provides interactions to a DSE node.
     """
 
-    def __init__(self, name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None, cassandra_version=None):
-        super(DseNode, self).__init__(name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables=environment_variables, cassandra_version=cassandra_version)
+    def __init__(self, name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None, derived_cassandra_version=None):
+        super(DseNode, self).__init__(name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables=environment_variables, derived_cassandra_version=derived_cassandra_version)
        
         self._dse_config_options = {}
         if self.cluster.hasOpscenter():

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -74,7 +74,7 @@ class Node(object):
     Provides interactions to a Cassandra node.
     """
 
-    def __init__(self, name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None, byteman_startup_script=None, cassandra_version=None):
+    def __init__(self, name, cluster, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None, byteman_startup_script=None, derived_cassandra_version=None):
         """
         Create a new Node.
           - name: the name for that node
@@ -112,8 +112,8 @@ class Node(object):
         self.__environment_variables = environment_variables or {}
         self.__conf_updated = False
 
-        if cassandra_version:
-            self._cassandra_version = cassandra_version
+        if derived_cassandra_version:
+            self._cassandra_version = derived_cassandra_version
         else:
             try:
                 self._cassandra_version = common.get_version_from_build(self.get_install_dir(), cassandra=True)
@@ -153,7 +153,7 @@ class Node(object):
             thrift_interface = None
             if 'thrift' in itf and itf['thrift'] is not None:
                 thrift_interface = tuple(itf['thrift'])
-            node = cluster.create_node(data['name'], data['auto_bootstrap'], thrift_interface, tuple(itf['storage']), data['jmx_port'], remote_debug_port, initial_token, save=False, binary_interface=binary_interface, byteman_port=data['byteman_port'], cassandra_version=cassandra_version)
+            node = cluster.create_node(data['name'], data['auto_bootstrap'], thrift_interface, tuple(itf['storage']), data['jmx_port'], remote_debug_port, initial_token, save=False, binary_interface=binary_interface, byteman_port=data['byteman_port'], derived_cassandra_version=cassandra_version)
             node.status = data['status']
             if 'pid' in data:
                 node.pid = int(data['pid'])


### PR DESCRIPTION
* Replaced cassandra_version overload with 'derived_cassandra_version'
  to avoid breaking backwards compatibility.
* Remove 'version' from config, if persisted it is reused and causes
  attempt to download version instead of using local directory.