### PR TITLE
Add support for new CASSANDRA-10404 yaml property

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -666,6 +666,9 @@ class Cluster(object):
             'truststore_password': 'cassandra'
         }
 
+        if self.cassandra_version() >= '4.0':
+            node_ssl_options['enabled'] = True
+
         self._config_options['server_encryption_options'] = node_ssl_options
         self._update_config()
 


### PR DESCRIPTION
if running 4.0 or higher and using ssl, set new `server_encryption_options. enabled` to true in yaml.

Note: committing this is required for CASSANDRA-10404