### PR TITLE
Update node version on install_dir change

### DIFF
--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -243,6 +243,8 @@ class Node(object):
         else:
             self.__install_dir = self.node_setup(version, verbose=verbose)
 
+        self._cassandra_version = common.get_version_from_build(self.__install_dir, cassandra=True)
+
         if self.get_base_cassandra_version() >= 4.0:
             self.network_interfaces['thrift'] = None
 


### PR DESCRIPTION
Is there any reason not to update the version value when changing the install directory for a node ([just as we do for cluster](https://github.com/pcmanus/ccm/blob/master/ccmlib/cluster.py#L96))? Otherwise this seems to cause issues for upgrade tests by sharing hints directories as described in 10f3ea95dee352a106bcb20182ec31354c490fc0.