### PR TITLE
Java 9 additions

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -700,9 +700,19 @@ def invalidate_cache():
 
 
 def get_jdk_version():
+    """
+    Retrieve the Java version as reported in the quoted string returned
+    by invoking 'java -version'.
+
+    Works for Java 1.8, Java 9 and should also be fine for Java 10.
+    """
     version = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
     ver_pattern = '\"(\d+\.\d+).*\"'
-    return re.search(ver_pattern, str(version)).groups()[0]
+    if re.search(ver_pattern, str(version)):
+        return re.search(ver_pattern, str(version)).groups()[0]
+    # like the output 'java version "9"' for 'java -version'
+    ver_pattern = '\"(\d+).*\"'
+    return re.search(ver_pattern, str(version)).groups()[0] + ".0"
 
 
 def assert_jdk_valid_for_cassandra_version(cassandra_version):

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -707,6 +707,10 @@ def get_jdk_version():
     Works for Java 1.8, Java 9 and should also be fine for Java 10.
     """
     version = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
+    return _get_jdk_version(version)
+
+
+def _get_jdk_version(version):
     ver_pattern = '\"(\d+\.\d+).*\"'
     if re.search(ver_pattern, str(version)):
         return re.search(ver_pattern, str(version)).groups()[0]

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1705,6 +1705,15 @@ class Node(object):
 
             common.replace_in_file(conf_file, gc_log_pattern, gc_log_setting)
 
+            # Java 9
+            gc_log_pattern = "-Xlog[:]gc=info"
+            if common.is_win():
+                gc_log_setting = '    $env:JVM_OPTS="$env:JVM_OPTS -Xlog:gc=info,heap=trace,age=debug,safepoint=info,promotion=trace:file={}:time,uptime,pid,tid,level:filecount=10,filesize=10240"'.format(gc_log_path)
+            else:
+                gc_log_setting = 'JVM_OPTS="$JVM_OPTS -Xlog:gc=info,heap=trace,age=debug,safepoint=info,promotion=trace:file={}:time,uptime,pid,tid,level:filecount=10,filesize=10240"'.format(gc_log_path)
+
+            common.replace_in_file(conf_file, gc_log_pattern, gc_log_setting)
+
         for itf in list(self.network_interfaces.values()):
             if itf is not None and common.interface_is_ipv6(itf):
                 if self.get_cassandra_version() < '3.2':

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -59,5 +59,42 @@ class TestCommon(ccmtest.Tester):
 
         self.assertEqual(common.merge_configuration(dict1, dict2), dict0)
 
+    def test_get_jdk_version(self):
+        v8u152 = """java version "1.8.0_152"
+                 Java(TM) SE Runtime Environment (build 1.8.0_152-b16)
+                 Java HotSpot(TM) 64-Bit Server VM (build 25.152-b16, mixed mode)
+                 """
+        # Since Java 9, the version string syntax changed.
+        # Most relevant change is that trailing .0's are omitted. I.e. Java "9.0.0"
+        # version string is not "9.0.0" but just "9".
+        v900 = """java version "9"
+               Java(TM) SE Runtime Environment (build 9+1)
+               Java HotSpot(TM) 64-Bit Server VM (build 9+1, mixed mode)
+               """
+        v901 = """java version "9.0.1"
+               Java(TM) SE Runtime Environment (build 9.0.1+11)
+               Java HotSpot(TM) 64-Bit Server VM (build 9.0.1+11, mixed mode)
+               """
+        # 10-internal, just to have an internal (local) build in here
+        v10_int = """openjdk version "10-internal"
+                  OpenJDK Runtime Environment (build 10-internal+0-adhoc.jenkins.openjdk-shenandoah-jdk10-release)
+                  OpenJDK 64-Bit Server VM (build 10-internal+0-adhoc.jenkins.openjdk-shenandoah-jdk10-release, mixed mode)
+                  """
+        v1000 = """java version "10"
+                Java(TM) SE Runtime Environment (build 9+1)
+                Java HotSpot(TM) 64-Bit Server VM (build 9+1, mixed mode)
+                """
+        v1001 = """java version "10.0.1"
+                Java(TM) SE Runtime Environment (build 10.0.1+11)
+                Java HotSpot(TM) 64-Bit Server VM (build 10.0.1+11, mixed mode)
+                """
+
+        self.assertEqual(common._get_jdk_version(v8u152), "1.8")
+        self.assertEqual(common._get_jdk_version(v900), "9.0")
+        self.assertEqual(common._get_jdk_version(v901), "9.0")
+        self.assertEqual(common._get_jdk_version(v10_int), "10.0")
+        self.assertEqual(common._get_jdk_version(v1000), "10.0")
+        self.assertEqual(common._get_jdk_version(v1001), "10.0")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes parsing of the version number (if the version number is just `9` or `10` for the `.0.0` releases).

Updates to GC-logging config for Java 9 and newer (applies to Java9 branch)