### PR TITLE
CASSANDRA-20328 Also copy tools/bin/cassandra.in.sh for tools

### DIFF
--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -42,6 +42,7 @@ from ccmlib import extension
 
 
 BIN_DIR = "bin"
+TOOLS_BIN_DIR = "tools/bin"
 CASSANDRA_CONF_DIR = "conf"
 
 CASSANDRA_CONF = "cassandra.yaml"
@@ -394,14 +395,18 @@ def rmdirs(path):
 
 def make_cassandra_env(install_dir, node_path, update_conf=True):
     version_from_build = extension.get_cluster_class(install_dir).getNodeClass().get_version_from_build(node_path=node_path)
-    if is_win() and version_from_build >= '2.1':
-        sh_file = os.path.join(CASSANDRA_CONF_DIR, CASSANDRA_WIN_ENV)
-    else:
-        sh_file = os.path.join(BIN_DIR, CASSANDRA_SH)
-    orig = os.path.join(install_dir, sh_file)
-    dst = os.path.join(node_path, sh_file)
-    if not is_win() or not os.path.exists(dst):
-        shutil.copy(orig, dst)
+    for sh_file_path in [ BIN_DIR, TOOLS_BIN_DIR ]:
+        if is_win() and version_from_build >= '2.1':
+            sh_file = os.path.join(CASSANDRA_CONF_DIR, CASSANDRA_WIN_ENV)
+        else:
+            sh_file = os.path.join(sh_file_path, CASSANDRA_SH)
+
+        orig = os.path.join(install_dir, sh_file)
+        if os.path.exists(orig):
+            dst = os.path.join(node_path, sh_file)
+            if not is_win() or not os.path.exists(dst):
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
+                shutil.copy(orig, dst)
 
     if update_conf and not (is_win() and version_from_build >= '2.1'):
         replacements = [


### PR DESCRIPTION
After [CASSANDRA-20328](https://issues.apache.org/jira/browse/CASSANDRA-20328), sstableloader has been updated to be a separate tool residing in the tools directory.

Existing dtests using sstableloader rely on make_cassandra_env which copies bin/cassandra.in.sh to the node's directory. As tools/bin/sstableloader now relies on tools/bin/cassandra.in.sh, updates this function to also copy this file to the node's path.

Note: There is some code that implies sstableloader should still be ran from `bin/sstableloader`.  I think we should keep that as we want to retain compatibility with previous C* versions, and the new changes in CASSANDRA-20328 still retain backwards compatibility with that path.