### PR TITLE
CASSANDRA-20536 – Improve support for upgrade testing across cluster types

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -448,6 +448,7 @@ class Cluster(object):
             node_tokens = stdout_output.replace('[','').replace(' ','').replace(']','').replace('\n','')
             tokens.append(node_tokens)
 
+        assert 0 < len(tokens), "No tokens generated from invocation: {}".format(str(cmd_list))
         common.debug("pregenerated tokens from cmd_list: {} are {}".format(str(cmd_list),tokens))
 
     def remove(self, node=None, gently=False):

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -888,7 +888,13 @@ def _update_java_version(current_java_version, current_java_home_version,
                            .format(current_java_version, current_java_home_version))
 
     if cassandra_version is None and install_dir:
-        cassandra_version = extension.get_cluster_class(install_dir).getNodeClass().get_version_from_build(install_dir, cassandra=True)
+        try:
+            node_class = extension.get_cluster_class(install_dir).getNodeClass()
+            cassandra_version = node_class.get_version_from_build(install_dir, cassandra=True)
+        except CCMError as e:
+            # when for_build cassandra_version=None is ok to pass to get_supported_jdk_versions(..)
+            if not for_build:
+                raise e
 
     # Java versions supported by the Cassandra distribution
     supported_versions = get_supported_jdk_versions(cassandra_version, install_dir, for_build, os_env if os_env else os.environ)

--- a/ccmlib/dse/dse_cluster.py
+++ b/ccmlib/dse/dse_cluster.py
@@ -242,14 +242,15 @@ def setup_opscenter(opscenter, username, password, verbose=False):
 
 
 def get_dse_cassandra_version(install_dir):
+    # for this to work, the current JAVA_HOME must already be appropriate
     dse_cmd = os.path.join(install_dir, 'bin', 'dse')
     (output, stderr) = subprocess.Popen([dse_cmd, "cassandra", '-v'], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
     # just take the last line to avoid any possible log lines
     output = output.decode('utf-8').rstrip().split('\n')[-1]
-    match = re.search('([0-9.]+)(?:-.*)?', str(output))
+    match = re.search('^([0-9.]+)(?:-.*)?', str(output))
     if match:
         return LooseVersion(match.group(1))
-    raise ArgumentError("Unable to determine Cassandra version in: %s.\n\tstdout: '%s'\n\tstderr: '%s'"
+    raise ArgumentError("Unable to determine Cassandra version using `bin/dse cassandra -v` from output: %s.\n\tstdout: '%s'\n\tstderr: '%s'"
                         % (install_dir, output, stderr))
 
 

--- a/ccmlib/dse/dse_node.py
+++ b/ccmlib/dse/dse_node.py
@@ -56,8 +56,6 @@ class DseNode(Node):
                     return get_dse_cassandra_version(install_dir)
                 else:
                     return LooseVersion(dse_version)
-            # Source cassandra installs we can read from build.xml
-            return Node.get_version_from_build(install_dir, cassandra)
         raise common.CCMError("Cannot find version")
 
 
@@ -93,6 +91,9 @@ class DseNode(Node):
         from ccmlib.dse.dse_cluster import setup_dse
         dir, v = setup_dse(version, self.cluster.dse_username, self.cluster.dse_password, verbose=verbose)
         return dir
+
+    def address_for_version(self, version):
+        return "{}".format(str(self.address()));
 
     def set_workloads(self, workloads):
         self.workloads = workloads
@@ -567,6 +568,7 @@ class DseNode(Node):
 
 
 def get_dse_version(install_dir):
+    """ look for a dse*.jar and extract the version number """
     for root, dirs, files in os.walk(install_dir):
         for file in files:
             match = re.search('^dse(?:-core)?-([0-9.]+)(?:-.*)?\.jar', file)

--- a/ccmlib/hcd/hcd_cluster.py
+++ b/ccmlib/hcd/hcd_cluster.py
@@ -135,6 +135,7 @@ def setup_hcd(version, verbose=False):
 
 
 def get_hcd_version(install_dir):
+    """ look for a hcd*.jar and extract the version number """
     for root, dirs, files in os.walk(install_dir):
         for file in files:
             match = re.search('^hcd(?:-core)?-([0-9.]+)(?:-.*)?\.jar', file)
@@ -144,6 +145,7 @@ def get_hcd_version(install_dir):
 
 
 def get_hcd_cassandra_version(install_dir):
+    # for this to work, the current JAVA_HOME must already be appropriate
     hcd_cmd = os.path.join(install_dir, 'bin', 'hcd')
     (output, stderr) = subprocess.Popen([hcd_cmd, "cassandra", '-v'], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
     # just take the last line to avoid any possible logback log lines

--- a/ccmlib/hcd/hcd_node.py
+++ b/ccmlib/hcd/hcd_node.py
@@ -55,8 +55,6 @@ class HcdNode(Node):
                     return get_hcd_cassandra_version(install_dir)
                 else:
                     return LooseVersion(hcd_version)
-            # Source cassandra installs we can read from build.xml
-            return Node.get_version_from_build(install_dir, cassandra)
         raise common.CCMError("Cannot find version")
 
 


### PR DESCRIPTION

This PR…
    1.  improves cluster and node handling when determining the cassandra version from build directories,
    2.  better failure handling and messaging around the use of `generatetokens`
    3.  fix for dse nodes not having port specified in their addresses