### PR TITLE
Fix panic when paramiko is installed

### DIFF
--- a/ccm
+++ b/ccm
@@ -24,20 +24,10 @@ import pkg_resources
 from six import print_
 
 from ccmlib import common
-from ccmlib.cmds import cluster_cmds, command, node_cmds
+from ccmlib.cmds import cluster_cmds, node_cmds
+from ccmlib.cmds.common import get_command
 from ccmlib.remote import (PARAMIKO_IS_AVAILABLE, execute_ccm_remotely,
                            get_remote_options, get_remote_usage)
-
-
-def get_command(kind, cmd):
-    cmd_name = kind.lower().capitalize() + cmd.lower().capitalize() + "Cmd"
-    try:
-        klass = (cluster_cmds if kind.lower() == 'cluster' else node_cmds).__dict__[cmd_name]
-    except KeyError:
-        return None
-    if not issubclass(klass, command.Cmd):
-        return None
-    return klass()
 
 
 def print_subcommand_usage(kind):

--- a/ccmlib/cmds/command.py
+++ b/ccmlib/cmds/command.py
@@ -25,6 +25,7 @@ import re
 
 from six import print_
 
+import ccmlib
 from ccmlib import common
 from ccmlib.cluster_factory import ClusterFactory
 from ccmlib.remote import PARAMIKO_IS_AVAILABLE, get_remote_usage
@@ -70,7 +71,8 @@ class Cmd(object):
     def get_parser(self):
         if self.usage == "":
             pass
-        if PARAMIKO_IS_AVAILABLE:
+        # Do not collapse to PARAMIKO_IS_AVAILABLE, we need to pull it dynamically for testing purposes
+        if ccmlib.remote.PARAMIKO_IS_AVAILABLE:
             self.usage = self.usage.replace("usage: ccm",
                                             "usage: ccm [remote_options]") + \
                          os.linesep + os.linesep + \

--- a/ccmlib/cmds/common.py
+++ b/ccmlib/cmds/common.py
@@ -1,0 +1,12 @@
+from ccmlib.cmds import cluster_cmds, command, node_cmds
+
+
+def get_command(kind, cmd):
+    cmd_name = kind.lower().capitalize() + cmd.lower().capitalize() + "Cmd"
+    try:
+        klass = (cluster_cmds if kind.lower() == 'cluster' else node_cmds).__dict__[cmd_name]
+    except KeyError:
+        return None
+    if not issubclass(klass, command.Cmd):
+        return None
+    return klass()

--- a/ccmlib/remote.py
+++ b/ccmlib/remote.py
@@ -510,9 +510,11 @@ class RemoteOptionsParser():
 
         :return Usage for the remote execution options
         """
-        # Retrieve the text for just the arguments
-        usage = self.parser.format_help().split("optional arguments:")[1]
-
+        remote_arguments_usage = self.parser.format_help()
+        chunks = re.split("^(optional arguments:|options:)", remote_arguments_usage)
+        if len(chunks) > 2:
+            # Try to extract argument description only, otherwise output the whole usage string
+            remote_arguments_usage = chunks[2]
         # Remove any blank lines and return
         return "Remote Options:" + os.linesep + \
-               os.linesep.join([s for s in usage.splitlines() if s])
+               os.linesep.join([s for s in remote_arguments_usage.splitlines() if s])

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -19,7 +19,6 @@ import os
 import sys
 import tempfile
 import time
-from distutils.version import LooseVersion  # pylint: disable=import-error, no-name-in-module
 from pathlib import Path
 
 import pytest
@@ -518,3 +517,23 @@ class TestErrorLogGrepping(ccmtest.Tester):
 
         err = '\n'.join([line1, line2, line3, line4])
         self.assertGreppedLog(err, [[line1], [line2], [line4]])
+
+
+class TestCCMCLI(ccmtest.Tester):
+    def test_help_message_with_paramiko(self):
+        self._test_help_message(True)
+
+    def test_help_message_without_paramiko(self):
+        self._test_help_message(False)
+
+    @staticmethod
+    def _test_help_message(paramiko: bool):
+        import ccmlib.remote
+        before = ccmlib.remote.PARAMIKO_IS_AVAILABLE
+        try:
+            ccmlib.remote.PARAMIKO_IS_AVAILABLE = paramiko
+            from ccmlib.cmds.common import get_command
+            cmd = get_command('cluster', 'create')
+            cmd.get_parser().print_help()
+        finally:
+            ccmlib.remote.PARAMIKO_IS_AVAILABLE = before


### PR DESCRIPTION
When `paramiko` is installed CCM is adding remote part of CLI. In order to build it, CCM reads renders `argparser` usage string. Recently `argparser` have changed format and now `optional arguments:` is not there anymore.
Fix code to not to fail in any case.

Failure:
```
ccm create gocql_cassandra_integration_test -i 127.0.2 -v 4.1.6 -n 3 -d --vnodes --jvm_arg="-Xmx256m -XX:NewSize=100m"

Traceback (most recent call last):
  File "/home/dmitry.kropachev/.local/bin/ccm", line 107, in <module>
    parser = cmd.get_parser()
  File "/home/dmitry.kropachev/.local/lib/python3.10/site-packages/ccmlib/cmds/command.py", line 60, in get_parser
    get_remote_usage()
  File "/home/dmitry.kropachev/.local/lib/python3.10/site-packages/ccmlib/remote.py", line 32, in get_remote_usage
    return RemoteOptionsParser().usage()
  File "/home/dmitry.kropachev/.local/lib/python3.10/site-packages/ccmlib/remote.py", line 497, in usage
    usage = self.parser.format_help().split("optional arguments:")[1]
IndexError: list index out of range
```