### PR TITLE
CASSANDRA-21311 Don't clobber dse file-provided credentials, and add matching download credentials capability to HCD.

### DIFF
--- a/ccmlib/dse/dse_cluster.py
+++ b/ccmlib/dse/dse_cluster.py
@@ -44,8 +44,14 @@ except ImportError:
 
 DSE_CASSANDRA_CONF_DIR = "resources/cassandra/conf"
 OPSCENTER_CONF_DIR = "conf"
-DSE_ARCHIVE = "https://downloads.datastax.com/enterprise/dse-%s-bin.tar.gz"
-OPSC_ARCHIVE = "https://downloads.datastax.com/enterprise/opscenter-%s.tar.gz"
+
+# DataStax Enterprise binaries are now gated and require authentication to download.
+# Download DSE and OpsCenter from: https://downloads.datastax.com/#enterprise
+# Place downloaded files in ~/Downloads/
+# Alternatively, configure custom URLs in ~/.ccm/config under [repositories] section.
+# Credentials for custom URLs can be configured in ~/.ccm/.dse.ini
+DSE_ARCHIVE = "file://~/Downloads/dse-%s-bin.tar.gz"
+OPSC_ARCHIVE = "file://~/Downloads/opscenter-%s.tar.gz"
 
 
 
@@ -96,8 +102,10 @@ class DseCluster(Cluster):
 
     def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, verbose=False, derived_cassandra_version=None, options=None):
         self.load_credentials_from_file(options.dse_credentials_file if options else None)
-        self.dse_username = options.dse_username if options else None
-        self.dse_password = options.dse_password if options else None
+        if options and options.dse_username:
+            self.dse_username = options.dse_username
+        if options and options.dse_password:
+            self.dse_password = options.dse_password
         self.opscenter = options.opscenter if options else None
         self._cassandra_version = None
         self._cassandra_version = derived_cassandra_version
@@ -260,6 +268,8 @@ def download_dse_version(version, username, password, verbose=False):
         url = repository.CCM_CONFIG.get('repositories', 'dse')
 
     url = url % version
+    if url.startswith('file://~'):
+        url = 'file://' + os.path.expanduser(url[7:])
     _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
     try:
         if username is None:
@@ -290,6 +300,8 @@ def download_opscenter_version(version, username, password, target_version, verb
         url = repository.CCM_CONFIG.get('repositories', 'opscenter')
 
     url = url % version
+    if url.startswith('file://~'):
+        url = 'file://' + os.path.expanduser(url[7:])
     _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
     try:
         if username is None:

--- a/ccmlib/hcd/__init__.py
+++ b/ccmlib/hcd/__init__.py
@@ -16,6 +16,7 @@
 
 
 from ccmlib import extension
+from ccmlib import common
 from ccmlib.cmds.cluster_cmds import ClusterCreateCmd
 from ccmlib.hcd.hcd_cluster import isHcdClusterType
 
@@ -25,4 +26,7 @@ from ccmlib.hcd.hcd_cluster import isHcdClusterType
 extension.CLUSTER_TYPES.append(isHcdClusterType)
 
 ClusterCreateCmd.options_list.extend([
-    (["--hcd"], {'action': "store_true", 'dest': "hcd", 'help': "Use with -v or --install-dir to indicate that the version being loaded is HCD"})])
+    (["--hcd"], {'action': "store_true", 'dest': "hcd", 'help': "Use with -v or --install-dir to indicate that the version being loaded is HCD"}),
+    (["--hcd-username"], {'type': "string", 'dest': "hcd_username", 'help': "The username to use to download HCD with", 'default': None}),
+    (["--hcd-password"], {'type': "string", 'dest': "hcd_password", 'help': "The password to use to download HCD with", 'default': None}),
+    (["--hcd-credentials"], {'type': "string", 'dest': "hcd_credentials_file", 'help': "An ini-style config file containing the hcd_username and hcd_password under a hcd_credentials section. [default to {}/.hcd.ini if it exists]".format(common.get_default_path_display_name()), 'default': None})])

--- a/ccmlib/hcd/hcd_cluster.py
+++ b/ccmlib/hcd/hcd_cluster.py
@@ -39,7 +39,13 @@ except ImportError:
 
 
 HCD_CASSANDRA_CONF_DIR = "resources/cassandra/conf"
-HCD_ARCHIVE = "https://downloads.datastax.com/hcd/hcd-%s-bin.tar.gz"
+
+# HCD binaries are now gated and require authentication to download.
+# Download DSE and OpsCenter from: https://downloads.datastax.com/#hcd
+# Place downloaded files in ~/Downloads/
+# Alternatively, configure custom URLs in ~/.ccm/config under [repositories] section.
+# Credentials for custom URLs can be configured in ~/.ccm/.hcd.ini
+HCD_ARCHIVE = "file://~/Downloads/hcd-%s-bin.tar.gz"
 
 
 def isHcd(install_dir, options=None):
@@ -76,6 +82,12 @@ class HcdCluster(Cluster):
 
 
     def __init__(self, path, name, partitioner=None, install_dir=None, create_directory=True, version=None, verbose=False, derived_cassandra_version=None, options=None):
+        self.load_credentials_from_file(options.hcd_credentials_file if options else None)
+        if options and options.hcd_username:
+            self.hcd_username = options.hcd_username
+        if options and options.hcd_password:
+            self.hcd_password = options.hcd_password
+
         self._cassandra_version = None
         if derived_cassandra_version:
             self._cassandra_version = derived_cassandra_version
@@ -88,6 +100,24 @@ class HcdCluster(Cluster):
     def load_from_repository(self, version, verbose):
         return setup_hcd(version, verbose)
 
+    def load_credentials_from_file(self, hcd_credentials_file):
+        # Use .hcd.ini if it exists in the default .ccm directory.
+        if hcd_credentials_file is None:
+            creds_file = os.path.join(common.get_default_path(), '.hcd.ini')
+            if os.path.isfile(creds_file):
+                hcd_credentials_file = creds_file
+
+        if hcd_credentials_file is not None:
+            parser = ConfigParser.RawConfigParser()
+            parser.read(hcd_credentials_file)
+            if parser.has_section('hcd_credentials'):
+                if parser.has_option('hcd_credentials', 'hcd_username'):
+                    self.dse_username = parser.get('hcd_credentials', 'hcd_username')
+                if parser.has_option('hcd_credentials', 'hcd_password'):
+                    self.dse_password = parser.get('hcd_credentials', 'hcd_password')
+            else:
+                common.warning("{} does not contain a 'hcd_credentials' section.".format(hcd_credentials_file))
+
     def create_node(self, name, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save=True, binary_interface=None, byteman_port='0', environment_variables=None, derived_cassandra_version=None, **kwargs):
         return HcdNode(name, self, auto_bootstrap, thrift_interface, storage_interface, jmx_port, remote_debug_port, initial_token, save, binary_interface, byteman_port, environment_variables=environment_variables, derived_cassandra_version=derived_cassandra_version, **kwargs)
 
@@ -97,15 +127,21 @@ class HcdCluster(Cluster):
         return self._cassandra_version
 
 
-def download_hcd_version(version, verbose=False):
+def download_hcd_version(version, username, password, verbose=False):
     url = HCD_ARCHIVE
     if repository.CCM_CONFIG.has_option('repositories', 'hcd'):
         url = repository.CCM_CONFIG.get('repositories', 'hcd')
 
     url = url % version
+    if url.startswith('file://~'):
+        url = 'file://' + os.path.expanduser(url[7:])
     _, target = tempfile.mkstemp(suffix=".tar.gz", prefix="ccm-")
     try:
-        repository.__download(url, target, show_progress=verbose)
+        if username is None:
+            common.warning("No hcd username detected, specify one using --hcd-username or passing in a credentials file using --hcd-credentials.")
+        if password is None:
+            common.warning("No hcd password detected, specify one using --hcd-password or passing in a credentials file using --hcd-credentials.")
+        repository.__download(url, target, username=username, password=password, show_progress=verbose)
         common.debug("Extracting {} as version {} ...".format(target, version))
         tar = tarfile.open(target)
         dir = tar.next().name.split("/")[0]  # pylint: disable=all


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSANDRA-21311