### PR TITLE
Find ant.exe on Windows PATH

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,11 +79,8 @@ Windows only:
   - cqlsh started from ccm show incorrect prompts on command-prompt
   - non nodetool-based command-line options fail (sstablesplit, scrub, etc)
   - To install psutil, you must use the .msi from pypi. pip install psutil will not work
-  - You will need ant.bat in your PATH in order to build C* from source
+  - You will need ant in your PATH in order to build C* from source
   - You must run with an Unrestricted Powershell Execution-Policy if using Cassandra 2.1.0+
-  - Ant installed via [chocolatey](https://chocolatey.org/) will not be found by ccm, so you must create a symbolic
-    link in order to fix the issue (as administrator):
-    - cmd /c mklink C:\ProgramData\chocolatey\bin\ant.bat C:\ProgramData\chocolatey\bin\ant.exe
 
 macOS only:
   - Airplay listens for incoming connections on 7000 so disable `Settings` -> `General` -> `AirDrop & Handoff` -> `AirPlay Receiver`

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -438,12 +438,12 @@ def make_cassandra_env(install_dir, node_path, update_conf=True):
 
 def check_win_requirements():
     if is_win():
-        # Make sure ant.bat is in the path and executable before continuing
+        # Make sure ant is in the path and executable before continuing
         try:
-            subprocess.Popen('ant.bat', stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            subprocess.Popen(platform_binary_on_path('ant'), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         except Exception:
             sys.exit(
-                "ERROR!  Could not find or execute ant.bat.  Please fix this before attempting to run ccm on Windows.")
+                "ERROR!  Could not find or execute ant.  Please fix this before attempting to run ccm on Windows.")
 
         # Confirm matching architectures
         # 32-bit python distributions will launch 32-bit cmd environments, losing PowerShell execution privileges on a 64-bit system
@@ -490,6 +490,36 @@ def join_bin(root, dir, executable):
 
 def platform_binary(input):
     return input + ".bat" if is_win() else input
+
+
+def platform_binary_on_path(input):
+    if not is_win():
+        return input
+
+    _, ext = os.path.splitext(input)
+    candidates = [input] if ext else [input + ".bat", input + ".cmd", input + ".exe", input]
+    for candidate in candidates:
+        path = find_executable_on_path(candidate)
+        if path:
+            return path
+
+    return platform_binary(input)
+
+
+def find_executable_on_path(executable):
+    if os.path.isabs(executable) and os.path.isfile(executable):
+        return executable
+
+    path = os.environ.get('PATH', '')
+    for directory in path.split(os.pathsep):
+        directory = directory.strip('"')
+        if not directory:
+            continue
+        candidate = os.path.join(directory, executable)
+        if os.path.isfile(candidate):
+            return candidate
+
+    return None
 
 
 def platform_pager():

--- a/ccmlib/repository.py
+++ b/ccmlib/repository.py
@@ -42,7 +42,7 @@ except ImportError:
 from ccmlib import common
 from ccmlib.common import (ArgumentError, CCMError,
                            update_java_version, get_default_path, get_jdk_version_int,
-                           platform_binary, rmdirs, validate_install_dir)
+                           platform_binary, platform_binary_on_path, rmdirs, validate_install_dir)
 from six.moves import urllib
 
 
@@ -250,7 +250,7 @@ def clone_development(git_repo, version, verbose=False, alias=False):
                 process = subprocess.Popen(['git', 'pull'], cwd=target_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 out, _, _ = log_info(process, logger)
                 assert out == 0, "Could not do a git pull"
-                process = subprocess.Popen([platform_binary('ant'), 'realclean'], cwd=target_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                process = subprocess.Popen([platform_binary_on_path('ant'), 'realclean'], cwd=target_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 out, _, _ = log_info(process, logger)
                 assert out == 0, "Could not run 'ant realclean'"
 
@@ -361,7 +361,7 @@ def compile_version(version, target_dir, verbose=False):
                 cmd = [mvnw, 'verify', '-DskipTest', '-DskipDocker','-DskipDeb','-DskipRPM','-DskipCqlsh', '-Pdatastax-artifactory']
             else:
                 # No gradle, use ant
-                cmd = [platform_binary('ant'), 'jar']
+                cmd = [platform_binary_on_path('ant'), 'jar']
                 if get_jdk_version_int(env=env) >= 11:
                     cmd.append('-Duse.jdk11=true')
         while attempt < 3 and ret_val != 0:
@@ -392,11 +392,11 @@ def compile_version(version, target_dir, verbose=False):
                 full_path = os.path.join(stress_bin_dir, f)
                 os.chmod(full_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
 
-            process = subprocess.Popen([platform_binary('ant'), 'build'], cwd=stress_dir, env=env,
+            process = subprocess.Popen([platform_binary_on_path('ant'), 'build'], cwd=stress_dir, env=env,
                                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             ret_val, _, _ = log_info(process, logger)
             if ret_val != 0:
-                process = subprocess.Popen([platform_binary('ant'), 'stress-build'], cwd=target_dir, env=env,
+                process = subprocess.Popen([platform_binary_on_path('ant'), 'stress-build'], cwd=target_dir, env=env,
                                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 ret_val, _, _ = log_info(process, logger)
                 if ret_val != 0:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -15,6 +15,9 @@
 # limitations under the License.
 
 
+import os
+import shutil
+import tempfile
 import unittest
 from mock import patch
 
@@ -56,6 +59,25 @@ class TestCommon(ccmtest.Tester):
         self.assertFalse(common.is_modern_windows_install(1.0))
         self.assertFalse(common.is_modern_windows_install('1.0'))
         self.assertFalse(common.is_modern_windows_install(LooseVersion('1.0')))
+
+    @patch('ccmlib.common.is_win')
+    def test_platform_binary_on_path_finds_windows_exe(self, mock_is_win):
+        mock_is_win.return_value = True
+        old_path = os.environ.get('PATH')
+        temp_dir = tempfile.mkdtemp()
+        try:
+            ant_exe = os.path.join(temp_dir, 'ant.exe')
+            with open(ant_exe, 'w'):
+                pass
+            os.environ['PATH'] = temp_dir
+
+            self.assertEqual(common.platform_binary_on_path('ant'), ant_exe)
+        finally:
+            if old_path is None:
+                os.environ.pop('PATH', None)
+            else:
+                os.environ['PATH'] = old_path
+            shutil.rmtree(temp_dir)
 
     def test_merge_configuration(self):
         # test for merging dict val in key, value pair


### PR DESCRIPTION
Fixes #405.

On Windows, `ant` can be available as `ant.exe` rather than only `ant.bat` (for example after a Chocolatey install). This adds a small PATH lookup helper for Ant, keeps the existing `.bat` fallback, and uses it for Cassandra builds.

I also removed the outdated Windows install note that asked users to create an `ant.bat` symlink.

Tested with:

```
uv run --with pytest==8.2.1 --with mock==5.1.0 --with pyyaml --with six --with psutil --with packaging --with pbr pytest tests/test_common.py -q
```