### PR TITLE
Remove remaining distutils usage

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -101,7 +101,7 @@ Remote Execution only:
 Installation
 ------------
 
-ccm uses python distutils so from the source directory run:
+ccm uses python setuptools so from the source directory run:
 
     sudo ./setup.py install
 

--- a/ccmlib/dse/dse_cluster.py
+++ b/ccmlib/dse/dse_cluster.py
@@ -27,7 +27,6 @@ import subprocess
 import tarfile
 import tempfile
 from argparse import ArgumentError
-from distutils.version import LooseVersion
 from six.moves import urllib
 
 from ccmlib import common, repository
@@ -35,6 +34,7 @@ from ccmlib.cluster import Cluster
 from ccmlib.common import rmdirs
 from ccmlib.common import ArgumentError
 from ccmlib.dse.dse_node import DseNode
+from ccmlib.version import LooseVersion
 
 try:
     import ConfigParser

--- a/ccmlib/dse/dse_node.py
+++ b/ccmlib/dse/dse_node.py
@@ -26,10 +26,10 @@ import signal
 import subprocess
 
 import yaml
-from distutils.version import LooseVersion
 
 from ccmlib import common, extension, node
 from ccmlib.node import Node, handle_external_tool_process
+from ccmlib.version import LooseVersion
 
 
 class DseNode(Node):

--- a/ccmlib/hcd/hcd_cluster.py
+++ b/ccmlib/hcd/hcd_cluster.py
@@ -25,12 +25,12 @@ import shutil
 import tarfile
 import tempfile
 from argparse import ArgumentError
-from distutils.version import LooseVersion
 
 from ccmlib import common, repository
 from ccmlib.cluster import Cluster
 from ccmlib.common import ArgumentError, rmdirs
 from ccmlib.hcd.hcd_node import HcdNode
+from ccmlib.version import LooseVersion
 
 try:
     import ConfigParser

--- a/ccmlib/hcd/hcd_node.py
+++ b/ccmlib/hcd/hcd_node.py
@@ -22,11 +22,11 @@ import os
 import shutil
 import yaml
 
-from distutils.version import LooseVersion
 from six.moves import urllib, xrange
 
 from ccmlib import common, node
 from ccmlib.node import Node
+from ccmlib.version import LooseVersion
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,7 @@
 from platform import system
 from shutil import copyfile
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 ccmscript = 'ccm'
 


### PR DESCRIPTION
## Summary
- replace the remaining DSE/HCD `distutils.version.LooseVersion` imports with the existing `ccmlib.version.LooseVersion` wrapper
- require `setuptools` directly in `setup.py` instead of falling back to `distutils.core`
- update the installation wording that still referred to distutils

Fixes #804

## Validation
- Not run locally