### PR TITLE
CASSANDRA-21506: Avoid Python dtest failure cascade by waiting for node socket release

### DIFF
--- a/ccmlib/cluster.py
+++ b/ccmlib/cluster.py
@@ -543,7 +543,7 @@ class Cluster(object):
             if not node.is_running():
                 for itf in node.network_interfaces.values():
                     if itf is not None:
-                        common.assert_socket_available(itf)
+                        common.wait_for_socket_available(itf)
 
         started = []
         for node in list(self.nodes.values()):

--- a/ccmlib/common.py
+++ b/ccmlib/common.py
@@ -567,6 +567,14 @@ def validate_install_dir(install_dir):
         raise ArgumentError('%s does not appear to be a %s installation directory (bin_dir: %s; conf_dir: %s)'
                             % (install_dir, extension.get_cluster_class(install_dir).__name__, bin_dir, conf_dir))
 
+def wait_for_socket_available(itf, timeout=15):
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            return assert_socket_available(itf)
+        except UnavailableSocketError:
+            time.sleep(1)
+    return assert_socket_available(itf)
 
 def assert_socket_available(itf):
     info = socket.getaddrinfo(itf[0], itf[1], socket.AF_UNSPEC, socket.SOCK_STREAM)

--- a/ccmlib/node.py
+++ b/ccmlib/node.py
@@ -1055,19 +1055,24 @@ class Node(object):
             else:
                 time.sleep(.1)
 
-            still_running = self.is_running()
-            if still_running and wait:
-                wait_time_sec = 1
-                for i in xrange(0, 7):
-                    # we'll double the wait time each try and cassandra should
-                    # not take more than 1 minute to shutdown
-                    time.sleep(wait_time_sec)
-                    if not self.is_running():
-                        return True
-                    wait_time_sec = wait_time_sec * 2
-                raise NodeError("Problem stopping node %s" % self.name)
-            else:
-                return True
+            if wait:
+                still_running = self.is_running()
+                if still_running:
+                    wait_time_sec = 1
+                    for i in xrange(0, 7):
+                        # we'll double the wait time each try and cassandra should
+                        # not take more than 1 minute to shutdown
+                        time.sleep(wait_time_sec)
+                        if not self.is_running():
+                            break
+                        wait_time_sec = wait_time_sec * 2
+                    else:
+                        raise NodeError("Problem stopping node %s" % self.name)
+
+                for itf in list(self.network_interfaces.values()):
+                    if itf is not None:
+                        common.wait_for_socket_available(itf)
+            return True
         else:
             # Make sure it is actually stopped even if the PID wasn't found for some reason
             # Always kill because it should already be stopped and we aren't waiting for it to stop


### PR DESCRIPTION
Ensure that CCM fully stops the node and releases addresses when wait=True.

Additionally, during start_cluster(), we can directly wait on ports to be available by retrying every 1 second up to the default timeout of 15 seconds per address.

Note: Fails fast; if one address is still not released by the timeout (default=15 seconds), it returns UnavailableSocketError rather than waiting for the others.

Each interface could use up almost the full 15s timeout in the worst case, which makes tests slower but more likely to succeed.

[Cassandra JIRA](https://issues.apache.org/jira/browse/CASSANDRA-21506)